### PR TITLE
chore: g8 template を元に各種library・初期コードなどを最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
 sbt take-test-coverage
 ```
 
-テストカバレッジは、`./target\scala-2.12\scoverage-report`に出力されます。
+テストカバレッジは、`./target/scala-2.13/scoverage-report`に出力されます。
 
 ## データベースのスキーマを更新する
 

--- a/app/entrypoint/src/main/scala/myapp/entrypoint/DIDesign.scala
+++ b/app/entrypoint/src/main/scala/myapp/entrypoint/DIDesign.scala
@@ -1,6 +1,6 @@
 package myapp.entrypoint
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import com.typesafe.config.Config
 import myapp.presentation.PresentationDIDesign
 import wvlet.airframe._
@@ -8,10 +8,10 @@ import wvlet.airframe._
 @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
 object DIDesign {
   @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity"))
-  def design(system: ActorSystem): Design =
+  def design(system: ActorSystem[Nothing]): Design =
     newDesign
-      .bind[ActorSystem].toInstance(system)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[MyApp].toSingleton
-      .bind[Config].toSingletonProvider[ActorSystem] { system => system.settings.config }
+      .bind[Config].toSingletonProvider[ActorSystem[Nothing]] { system => system.settings.config }
       .add(PresentationDIDesign.presentationDesign)
 }

--- a/app/entrypoint/src/main/scala/myapp/entrypoint/Main.scala
+++ b/app/entrypoint/src/main/scala/myapp/entrypoint/Main.scala
@@ -1,6 +1,8 @@
 package myapp.entrypoint
 
-import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.Cluster
 import com.typesafe.config.ConfigFactory
 import lerna.log.AppLogging
@@ -34,7 +36,8 @@ object Main extends App with AppLogging {
     System.exit(1)
   }
 
-  private val system: ActorSystem = ActorSystem("MyAppSystem", config)
+  private val system: ActorSystem[Nothing] =
+    ActorSystem[Nothing](Behaviors.empty, "MyAppSystem", config)
   logger.info("ActorSystem({})起動完了", system)
 
   val cluster = Cluster(system)

--- a/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
+++ b/app/entrypoint/src/main/scala/myapp/entrypoint/MyApp.scala
@@ -1,7 +1,8 @@
 package myapp.entrypoint
 
 import akka.Done
-import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.server.Route
@@ -12,11 +13,11 @@ import myapp.presentation.RootRoute
 
 @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
 class MyApp(implicit
-    val actorSystem: ActorSystem,
+    val actorSystem: ActorSystem[Nothing],
     rootRoute: RootRoute,
     config: Config,
 ) extends AppLogging {
-  import actorSystem.dispatcher
+  import actorSystem.executionContext
 
   def start(): Unit = {
     val privateInternetInterface = config.getString("myapp.private-internet.http.interface")

--- a/app/entrypoint/src/test/scala/myapp/entrypoint/DIDesignSpec.scala
+++ b/app/entrypoint/src/test/scala/myapp/entrypoint/DIDesignSpec.scala
@@ -1,6 +1,7 @@
 package myapp.entrypoint
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.Config
 import lerna.testkit.airframe.DISessionSupport
 import myapp.utility.scalatest.StandardSpec
@@ -9,7 +10,7 @@ import wvlet.airframe.Design
 @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
 class DIDesignSpec extends StandardSpec with DISessionSupport {
 
-  private val system: ActorSystem = ActorSystem()
+  private val system = ActorSystem(Behaviors.empty, "MyAppSystem")
 
   override protected val diDesign: Design = DIDesign.design(system).withProductionMode
 

--- a/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
+++ b/app/testkit/src/main/scala/myapp/utility/scalatest/StandardSpec.scala
@@ -1,7 +1,7 @@
 package myapp.utility.scalatest
 
 import lerna.util.lang.Equals
-import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 trait StandardSpec extends AnyWordSpecLike with SpecAssertions with Equals with Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "1.0.0+157-482a23b1-SNAPSHOT"
-    val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
+    val akkaEntityReplication    = "1.0.0+183-38b36c52-SNAPSHOT"
+    val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"

--- a/scripts/start-app-1.sh
+++ b/scripts/start-app-1.sh
@@ -8,7 +8,6 @@ sbt \
 -Dakka.cluster.seed-nodes.1="akka://MyAppSystem@127.0.0.2:25520" \
 -Dakka.remote.artery.canonical.hostname="127.0.0.1" \
 -Dmyapp.server-mode=DEV \
--Dmyapp.public-internet.http.interface="127.0.0.1" \
 -Dmyapp.private-internet.http.interface="127.0.0.1" \
 -Dmyapp.management.http.interface="127.0.0.1" \
 entrypoint/run

--- a/scripts/start-app-2.sh
+++ b/scripts/start-app-2.sh
@@ -8,7 +8,6 @@ sbt \
 -Dakka.cluster.seed-nodes.1="akka://MyAppSystem@127.0.0.2:25520" \
 -Dakka.remote.artery.canonical.hostname="127.0.0.2" \
 -Dmyapp.server-mode=DEV \
--Dmyapp.public-internet.http.interface="127.0.0.2" \
 -Dmyapp.private-internet.http.interface="127.0.0.2" \
 -Dmyapp.management.http.interface="127.0.0.2" \
 entrypoint/run


### PR DESCRIPTION
https://github.com/lerna-stack/lerna-sample-account-app/issues/5 ```lerna-app-library と akka-entity-replication を併用する場合の例を作成 · Issue #5 · lerna-stack/lerna-sample-account-app```

## 参考
- lerna-stack/lerna.g8 at develop
https://github.com/lerna-stack/lerna.g8/tree/develop