### PR TITLE
マルチテナント対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,59 @@ curl --silent --noproxy "*" http://127.0.0.2:9002/commit-hash
 ポート番号 `9001` は ユーザ向け機能、  
 ポート番号 `9002` は 管理用機能を定義することを想定しています。
 
+### Bank Accounts
+#### 残高確認
+- method: `GET`
+- path: `/accounts/${accountNo}`
+- headers
+    - `X-Tenant-Id`: `${tenantId}`
+        - `tenant-a`
+        - `tenant-b`
+
+```shell
+curl \
+    --silent \
+    --show-error \
+    --request 'GET' \
+    --url 'http://127.0.0.1:9001/accounts/test33' \
+    --header 'X-Tenant-Id: tenant-a' \
+```
+
+#### 入金
+- method: `GET`
+- path: `/accounts/${accountNo}/deposit`
+- (query) parameters
+    - `transactionId` (number)
+    - `amount` (number)
+- headers
+    - `X-Tenant-Id`: `${tenantId}`
+
+```shell
+curl \
+    --silent \
+    --show-error \
+    --request 'POST' \
+    --url "http://127.0.0.1:9001/accounts/test33/deposit?transactionId=$(date '+%s')&amount=600" \
+    --header 'X-Tenant-Id: tenant-a' \
+```
+
+#### 出金
+- method: `GET`
+- path: `/accounts/${accountNo}/withdraw`
+- (query) parameters
+    - `transactionId` (number)
+    - `amount` (number)
+- headers
+    - `X-Tenant-Id`: `${tenantId}`
+
+```shell
+curl \
+    --silent \
+    --show-error \
+    --request 'POST' \
+    --url "http://127.0.0.1:9001/accounts/test33/withdraw?transactionId=$(date '+%s')&amount=500" \
+    --header 'X-Tenant-Id: tenant-a' \
+```
 
 ## テストカバレッジ を取得する
 

--- a/app/application/src/main/resources/reference.conf
+++ b/app/application/src/main/resources/reference.conf
@@ -19,14 +19,17 @@ akka.extensions = [
 akka.persistence {
   journal {
     auto-start-journals = [
-      "akka-entity-replication.raft.persistence.cassandra.journal",
-      "akka-entity-replication.eventsourced.persistence.cassandra.journal",
+      "akka-entity-replication.raft.persistence.cassandra-tenant-a.journal",
+      "akka-entity-replication.raft.persistence.cassandra-tenant-b.journal",
+      "akka-entity-replication.eventsourced.persistence.cassandra-tenant-a.journal",
+      "akka-entity-replication.eventsourced.persistence.cassandra-tenant-b.journal",
     ]
   }
 
   snapshot-store {
     auto-start-snapshot-stores = [
-      "akka-entity-replication.raft.persistence.cassandra.snapshot",
+      "akka-entity-replication.raft.persistence.cassandra-tenant-a.snapshot",
+      "akka-entity-replication.raft.persistence.cassandra-tenant-b.snapshot",
     ]
   }
 }
@@ -42,14 +45,15 @@ lerna.akka.entityreplication.raft.multi-raft-roles = [
   "replica-group-3",
 ]
 
+// 動的に plugin 設定する場合でも、 "" 以外を設定しておかないと起動時エラーになるため
 lerna.akka.entityreplication {
   raft.persistence {
-    journal.plugin        = "akka-entity-replication.raft.persistence.cassandra.journal"
-    snapshot-store.plugin = "akka-entity-replication.raft.persistence.cassandra.snapshot"
-    query.plugin          = "akka-entity-replication.raft.persistence.cassandra.query"
+    journal.plugin        = "akka-entity-replication.raft.persistence.dummy.journal"
+    snapshot-store.plugin = "akka-entity-replication.raft.persistence.dummy.snapshot"
+    query.plugin          = "akka-entity-replication.raft.persistence.dummy.query"
   }
   raft.eventsourced.persistence {
-    journal.plugin  = "akka-entity-replication.eventsourced.persistence.cassandra.journal"
+    journal.plugin  = "akka-entity-replication.eventsourced.persistence.dummy.journal"
   }
 }
 
@@ -97,6 +101,15 @@ akka-entity-replication.raft.persistence.cassandra = ${akka.persistence.cassandr
   }
 }
 
+akka-entity-replication.raft.persistence.cassandra-tenant-a  = ${akka-entity-replication.raft.persistence.cassandra} {
+  journal.keyspace = "entity_replication_tenant_a"
+  snapshot.keyspace = "entity_replication_snapshot_tenant_a"
+}
+akka-entity-replication.raft.persistence.cassandra-tenant-b = ${akka-entity-replication.raft.persistence.cassandra} {
+  journal.keyspace = "entity_replication_tenant_b"
+  snapshot.keyspace = "entity_replication_snapshot_tenant_b"
+}
+
 // The settings for Cassandra persistence plugin to handle query side
 // You can set anything name for the root key of these settings
 akka-entity-replication.eventsourced.persistence.cassandra = ${akka.persistence.cassandra} {
@@ -117,6 +130,13 @@ akka-entity-replication.eventsourced.persistence.cassandra = ${akka.persistence.
     // Name of the keyspace to be used by the journal
     keyspace = "raft_commited_event"
   }
+}
+
+akka-entity-replication.eventsourced.persistence.cassandra-tenant-a  = ${akka-entity-replication.eventsourced.persistence.cassandra} {
+  journal.keyspace = "raft_commited_event_tenant_a"
+}
+akka-entity-replication.eventsourced.persistence.cassandra-tenant-b = ${akka-entity-replication.eventsourced.persistence.cassandra} {
+  journal.keyspace = "raft_commited_event_tenant_b"
 }
 
 // You can find reference configuration at

--- a/app/application/src/main/scala/myapp/application/account/BankAccountBehavior.scala
+++ b/app/application/src/main/scala/myapp/application/account/BankAccountBehavior.scala
@@ -6,13 +6,15 @@ import lerna.akka.entityreplication.typed._
 import lerna.log.{ AppLogger, AppTypedActorLogging }
 import myapp.adapter.account.TransactionId
 import myapp.utility.AppRequestContext
+import myapp.utility.tenant.AppTenant
 
 import scala.collection.immutable.ListMap
 import scala.concurrent.duration._
 
 object BankAccountBehavior extends AppTypedActorLogging {
 
-  val TypeKey: ReplicatedEntityTypeKey[Command] = ReplicatedEntityTypeKey("BankAccount")
+  def typeKey(implicit tenant: AppTenant): ReplicatedEntityTypeKey[Command] =
+    ReplicatedEntityTypeKey(s"BankAccount-${tenant.id}")
 
   sealed trait Command
   final case class Deposit(transactionId: TransactionId, amount: BigInt, replyTo: ActorRef[DepositSucceeded])(implicit

--- a/app/application/src/test/scala/myapp/application/account/BankAccountBehaviorSpec.scala
+++ b/app/application/src/test/scala/myapp/application/account/BankAccountBehaviorSpec.scala
@@ -19,7 +19,7 @@ class BankAccountBehaviorSpec extends ScalaTestWithTypedActorTestKit() with AnyW
   private[this] val bankAccountTestKit =
     ReplicatedEntityBehaviorTestKit[Command, DomainEvent, Account](
       system,
-      BankAccountBehavior.TypeKey,
+      BankAccountBehavior.typeKey(tenant),
       entityId = "test-entity",
       behavior = context => BankAccountBehavior(context),
     )

--- a/app/application/src/test/scala/myapp/application/account/BankAccountBehaviorSpec.scala
+++ b/app/application/src/test/scala/myapp/application/account/BankAccountBehaviorSpec.scala
@@ -6,12 +6,15 @@ import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.util.trace.TraceId
 import myapp.adapter.account.TransactionId
 import myapp.utility.AppRequestContext
+import myapp.utility.tenant.TenantA
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class BankAccountBehaviorSpec extends ScalaTestWithTypedActorTestKit() with AnyWordSpecLike with BeforeAndAfterEach {
 
   import BankAccountBehavior._
+
+  private[this] val tenant = TenantA
 
   private[this] val bankAccountTestKit =
     ReplicatedEntityBehaviorTestKit[Command, DomainEvent, Account](
@@ -26,7 +29,7 @@ class BankAccountBehaviorSpec extends ScalaTestWithTypedActorTestKit() with AnyW
     super.afterEach()
   }
 
-  implicit private val appRequestContext: AppRequestContext = AppRequestContext(TraceId.unknown)
+  implicit private val appRequestContext: AppRequestContext = AppRequestContext(TraceId.unknown, tenant)
 
   "A BankAccountBehavior" should {
 

--- a/app/presentation/src/main/scala/myapp/presentation/application/ApplicationRoute.scala
+++ b/app/presentation/src/main/scala/myapp/presentation/application/ApplicationRoute.scala
@@ -9,11 +9,11 @@ import myapp.presentation.util.directives.AppRequestContextDirective
 class ApplicationRoute(bankAccountApplication: BankAccountApplication) extends AppRequestContextDirective {
   import ApplicationRoute._
 
-  def route: Route = extractAppRequestContext { implicit appRequestContext =>
-    concat(
-      path("index") {
-        complete(StatusCodes.OK -> "OK")
-      },
+  def route: Route = concat(
+    path("index") {
+      complete(StatusCodes.OK -> "OK")
+    },
+    extractAppRequestContext { implicit appRequestContext =>
       pathPrefix("accounts" / Segment.map(AccountNo)) { accountNo =>
         concat(
           get {
@@ -36,9 +36,9 @@ class ApplicationRoute(bankAccountApplication: BankAccountApplication) extends A
             )
           },
         )
-      },
-    )
-  }
+      }
+    },
+  )
 }
 
 object ApplicationRoute {

--- a/app/presentation/src/main/scala/myapp/presentation/util/directives/AppRequestContextDirective.scala
+++ b/app/presentation/src/main/scala/myapp/presentation/util/directives/AppRequestContextDirective.scala
@@ -3,13 +3,13 @@ package myapp.presentation.util.directives
 import akka.http.scaladsl.server.Directive1
 import lerna.http.directives.GenTraceIDDirective
 import myapp.utility.AppRequestContext
-import myapp.utility.tenant.TenantA
 
-trait AppRequestContextDirective extends GenTraceIDDirective {
+trait AppRequestContextDirective extends GenTraceIDDirective with AppTenantDirective {
   protected def extractAppRequestContext: Directive1[AppRequestContext] =
     for {
       traceId <- extractTraceId
+      tenant  <- extractTenantStrict
     } yield {
-      AppRequestContext(traceId, TenantA)
+      AppRequestContext(traceId, tenant)
     }
 }

--- a/app/presentation/src/main/scala/myapp/presentation/util/directives/AppRequestContextDirective.scala
+++ b/app/presentation/src/main/scala/myapp/presentation/util/directives/AppRequestContextDirective.scala
@@ -3,12 +3,13 @@ package myapp.presentation.util.directives
 import akka.http.scaladsl.server.Directive1
 import lerna.http.directives.GenTraceIDDirective
 import myapp.utility.AppRequestContext
+import myapp.utility.tenant.TenantA
 
 trait AppRequestContextDirective extends GenTraceIDDirective {
   protected def extractAppRequestContext: Directive1[AppRequestContext] =
     for {
       traceId <- extractTraceId
     } yield {
-      AppRequestContext(traceId)
+      AppRequestContext(traceId, TenantA)
     }
 }

--- a/app/presentation/src/main/scala/myapp/presentation/util/directives/AppTenantDirective.scala
+++ b/app/presentation/src/main/scala/myapp/presentation/util/directives/AppTenantDirective.scala
@@ -1,0 +1,49 @@
+package myapp.presentation.util.directives
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{ Directive1, MalformedHeaderRejection, MissingHeaderRejection }
+import lerna.log.AppLogging
+import myapp.utility.tenant.AppTenant
+
+import scala.util.{ Failure, Success, Try }
+
+object AppTenantDirective {
+  private val headerName = "X-Tenant-Id"
+}
+
+trait AppTenantDirective extends AppLogging {
+
+  import AppTenantDirective.headerName
+
+  /** 以下の場合、HTTPリクエストは拒否される<br>
+    * <li>テナント用HTTPヘッダーが無く、テナントが不明の場合</li>
+    * <li>テナントIDが未知の値の場合 (Tenant class で受付可能な id を定義)</li>
+    */
+  private[directives] def extractTenantStrict: Directive1[AppTenant] = {
+    extractTenant.flatMap { maybeTriedTenant =>
+      import lerna.log.SystemComponentLogContext.logContext
+
+      maybeTriedTenant match {
+        case Some(Success(tenant)) =>
+          provide(tenant)
+        case Some(Failure(exception)) =>
+          val message =
+            s"""HTTP Header "$headerName" にテナントIDとして有効な値(${AppTenant.values.map(_.id).mkString(", ")})を指定してください。"""
+          logger.warn(exception, message)
+          reject(MalformedHeaderRejection(headerName, message, Option(exception)))
+        case None =>
+          logger.info(s"""HTTP Header "$headerName" が存在しません。Header を付与してください。""")
+          reject(MissingHeaderRejection(headerName))
+      }
+    }
+  }
+
+  private[this] def extractTenant: Directive1[Option[Try[AppTenant]]] = {
+    for {
+      maybeTenantId <- optionalHeaderValueByName(headerName)
+    } yield {
+      maybeTenantId.map { id =>
+        Try(AppTenant.withId(id))
+      }
+    }
+  }
+}

--- a/app/presentation/src/test/scala/myapp/presentation/util/directives/AppTenantDirectiveSpec.scala
+++ b/app/presentation/src/test/scala/myapp/presentation/util/directives/AppTenantDirectiveSpec.scala
@@ -1,0 +1,67 @@
+package myapp.presentation.util.directives
+
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.{ MalformedHeaderRejection, MissingHeaderRejection, Route }
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.Inside
+import myapp.utility.scalatest.StandardSpec
+import myapp.utility.tenant.TenantA
+
+class AppTenantDirectiveSpec extends StandardSpec with ScalatestRouteTest with Inside {
+  private val tenantHeaderName = "X-Tenant-Id"
+
+  private def tenantHeader(value: String): RawHeader = RawHeader(tenantHeaderName, value)
+
+  private val testRoute = new AppTenantDirectiveSpec.TestRoute
+
+  "extractTenantStrict" should {
+    val route = testRoute.strictRoute
+
+    "テナントHeaderが存在する（存在するテナント）" when {
+      val request = Get("/").withHeaders(tenantHeader(TenantA.id))
+      "テナントを得られる" in {
+        request ~> route ~> check {
+          expect {
+            handled
+            responseAs[String] === TenantA.id
+          }
+        }
+      }
+    }
+
+    "テナントHeaderが存在する（存在しないテナント）" when {
+      val request = Get("/").withHeaders(tenantHeader("__dummy__"))
+      "ログ出力＆rejectされる" in {
+        request ~> route ~> check {
+          // ログは目視で確認
+          inside(rejection) {
+            case malformedHeaderRejection: MalformedHeaderRejection =>
+              expect(malformedHeaderRejection.headerName === tenantHeaderName)
+          }
+        }
+      }
+    }
+
+    "テナントHeaderが存在しない" when {
+      val request = Get("/")
+      "ログ出力＆rejectされる" in {
+        request ~> route ~> check {
+          // ログは目視で確認
+          inside(rejection) {
+            case MissingHeaderRejection(headerName) =>
+              expect(headerName === tenantHeaderName)
+          }
+        }
+      }
+    }
+  }
+}
+
+object AppTenantDirectiveSpec {
+  private class TestRoute extends AppTenantDirective {
+    val strictRoute: Route = extractTenantStrict { tenant =>
+      complete(tenant.id)
+    }
+  }
+}

--- a/app/utility/src/main/resources/logback.xml
+++ b/app/utility/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{yyyy-MM-dd HH:mm:ss.SSS}\t%-5level\t%logger\t%X{actorPath:--}\t%X{traceId:--}\t%msg%n%xEx%nopex%n</pattern>
+            <pattern>%date{yyyy-MM-dd HH:mm:ss.SSS}\t%-5level\t%logger\t%X{actorPath:--}\t%X{traceId:--}\t%X{tenantId:--}\t%msg%n%xEx%nopex%n</pattern>
         </encoder>
     </appender>
 

--- a/app/utility/src/main/scala/myapp/utility/AppRequestContext.scala
+++ b/app/utility/src/main/scala/myapp/utility/AppRequestContext.scala
@@ -1,10 +1,8 @@
 package myapp.utility
 
-import lerna.util.tenant.Tenant
 import lerna.util.trace.TraceId
+import myapp.utility.tenant.{ AppTenant, TenantA }
 
 final case class AppRequestContext(traceId: TraceId) extends lerna.util.trace.RequestContext {
-  override implicit def tenant: Tenant = new Tenant {
-    override def id: String = "nothing"
-  }
+  override implicit def tenant: AppTenant = TenantA
 }

--- a/app/utility/src/main/scala/myapp/utility/AppRequestContext.scala
+++ b/app/utility/src/main/scala/myapp/utility/AppRequestContext.scala
@@ -1,8 +1,6 @@
 package myapp.utility
 
 import lerna.util.trace.TraceId
-import myapp.utility.tenant.{ AppTenant, TenantA }
+import myapp.utility.tenant.AppTenant
 
-final case class AppRequestContext(traceId: TraceId) extends lerna.util.trace.RequestContext {
-  override implicit def tenant: AppTenant = TenantA
-}
+final case class AppRequestContext(traceId: TraceId, tenant: AppTenant) extends lerna.util.trace.RequestContext

--- a/app/utility/src/main/scala/myapp/utility/tenant/AppTenant.scala
+++ b/app/utility/src/main/scala/myapp/utility/tenant/AppTenant.scala
@@ -1,0 +1,30 @@
+package myapp.utility.tenant
+
+import lerna.util.lang.Equals._
+import myapp.utility.AppRequestContext
+
+trait AppTenant extends lerna.util.tenant.Tenant
+
+object AppTenant {
+  // テナントを追加したときは人力による追加が必要
+  val values: Seq[AppTenant] = Seq[AppTenant](
+    TenantA,
+    TenantB,
+  )
+
+  def withId(id: String): AppTenant = values.find(_.id === id).getOrElse {
+    throw new NoSuchElementException(s"No Tenant found for '$id'")
+  }
+
+  implicit def tenant(implicit appRequestContext: AppRequestContext): AppTenant = appRequestContext.tenant
+}
+
+sealed abstract class TenantA extends AppTenant
+case object TenantA extends TenantA {
+  override def id: String = "tenant-a"
+}
+
+sealed abstract class TenantB extends AppTenant
+case object TenantB extends TenantB {
+  override def id: String = "tenant-b"
+}


### PR DESCRIPTION
https://github.com/lerna-stack/lerna-sample-account-app/issues/5 ```lerna-app-library と akka-entity-replication を併用する場合の例を作成 · Issue #5 · lerna-stack/lerna-sample-account-app```

## 動作確認
### keyspace
テナントごとに作成されている
```
cassandra@cqlsh> DESC KEYSPACES

akka_snapshot                         system
entity_replication_snapshot_tenant_b  system_distributed
entity_replication_snapshot_tenant_a  system_traces
entity_replication_tenant_b           raft_commited_event_tenant_a
system_schema                         entity_replication_tenant_a
system_auth                           raft_commited_event_tenant_b
```
### 入金
```shell
$ curl \
> --silent \
> --show-error \
> --request 'POST' \
> --url "http://127.0.0.1:9001/accounts/test42/deposit?transactionId=$(date '+%s')&amount=600" \
> --header 'X-Tenant-Id: tenant-a' \
>
600
```
ログ

> `2021-07-02 18:22:09.534 INFO    myapp.application.account.BankAccountBehavior$  akka://MyAppSystem/system/sharding/raft-shard-BankAccount-tenant-a-replica-group-2/47/56/test42      99999999999     tenant-a        [LEADER] Deposited(TransactionId(1625217727),600) [balance: 600, resent-transactions: 1]`

### 出金
```shell
$ curl \
> --silent \
> --show-error \
> --request 'POST' \
> --url "http://127.0.0.1:9001/accounts/test42/withdraw?transactionId=$(date '+%s')&amount=500" \
> --header 'X-Tenant-Id: tenant-a' \
>
100
```
ログ

> `2021-07-02 18:22:28.204 INFO    myapp.application.account.BankAccountBehavior$  akka://MyAppSystem/system/sharding/raft-shard-BankAccount-tenant-a-replica-group-2/47/56/test42      99999999999     tenant-a        [LEADER] Withdrew(TransactionId(1625217748),500) [balance: 100, resent-transactions: 2]`

### 残高確認
```shell
$ curl \
> --silent \
> --show-error \
> --request 'GET' \
> --url 'http://127.0.0.1:9001/accounts/test42' \
> --header 'X-Tenant-Id: tenant-a' \
>
100
```
### 別テナントで残高確認
残高は 存在しない

```shell
$ curl \
> --silent \
> --show-error \
> --request 'GET' \
> --url 'http://127.0.0.1:9001/accounts/test42' \
> --header 'X-Tenant-Id: tenant-b' \
>
0
```