### PR TITLE
feat: HTTPリクエストレスポンスをログ出力

### DIFF
--- a/app/presentation/src/main/scala/myapp/presentation/application/ApplicationRoute.scala
+++ b/app/presentation/src/main/scala/myapp/presentation/application/ApplicationRoute.scala
@@ -3,10 +3,13 @@ package myapp.presentation.application
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import lerna.http.directives.RequestLogDirective
 import myapp.adapter.account.{ AccountNo, BankAccountApplication, TransactionId }
 import myapp.presentation.util.directives.AppRequestContextDirective
 
-class ApplicationRoute(bankAccountApplication: BankAccountApplication) extends AppRequestContextDirective {
+class ApplicationRoute(bankAccountApplication: BankAccountApplication)
+    extends AppRequestContextDirective
+    with RequestLogDirective {
   import ApplicationRoute._
 
   def route: Route = concat(
@@ -14,7 +17,7 @@ class ApplicationRoute(bankAccountApplication: BankAccountApplication) extends A
       complete(StatusCodes.OK -> "OK")
     },
     extractAppRequestContext { implicit appRequestContext =>
-      pathPrefix("accounts" / Segment.map(AccountNo)) { accountNo =>
+      (logRequestDirective & logRequestResultDirective & pathPrefix("accounts" / Segment.map(AccountNo))) { accountNo =>
         concat(
           get {
             onSuccess(bankAccountApplication.fetchBalance(accountNo)) { result =>


### PR DESCRIPTION
https://github.com/lerna-stack/lerna-sample-account-app/issues/5 ```lerna-app-library と akka-entity-replication を併用する場合の例を作成 · Issue #5 · lerna-stack/lerna-sample-account-app```

## 動作確認
```
2021-07-02 21:12:38.611 INFO    myapp.presentation.application.ApplicationRoute -       99999999999     tenant-a    Request: [POST] /accounts/test42/deposit?transactionId=1625227958&amount=600, RequestHeaders: [Timeout-Access: <function1>, Host, User-Agent: curl/7.73.0, Accept: */*, X-Tenant-Id: tenant-a]

2021-07-02 21:12:40.401 INFO    myapp.presentation.application.ApplicationRoute -       99999999999     tenant-a    Response: /accounts/test42/deposit?transactionId=1625227958&amount=600 : 200 OK, ResponseHeaders: [], RequestBody: , ResponseBody: 600

2021-07-02 21:12:41.512 INFO    myapp.presentation.application.ApplicationRoute -       99999999999     tenant-a    Request: [POST] /accounts/test42/withdraw?transactionId=1625227961&amount=500, RequestHeaders: [Timeout-Access: <function1>, Host, User-Agent: curl/7.73.0, Accept: */*, X-Tenant-Id: tenant-a]

2021-07-02 21:12:41.544 INFO    myapp.presentation.application.ApplicationRoute -       99999999999     tenant-a    Response: /accounts/test42/withdraw?transactionId=1625227961&amount=500 : 200 OK, ResponseHeaders: [], RequestBody: , ResponseBody: 100

2021-07-02 21:13:04.460 INFO    myapp.presentation.application.ApplicationRoute -       99999999999     tenant-a    Request: [GET] /accounts/test42, RequestHeaders: [Timeout-Access: <function1>, Host, User-Agent: curl/7.73.0, Accept: */*, X-Tenant-Id: tenant-a]

2021-07-02 21:13:04.628 INFO    myapp.presentation.application.ApplicationRoute -       99999999999     tenant-a    Response: /accounts/test42 : 200 OK, ResponseHeaders: [], RequestBody: , ResponseBody: 100
```