### PR TITLE
chore: docker-compose up 時にデフォルトで sbt-rpmbuild を作成しないように変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       retries: 60
 
   sbt-rpmbuild:
+    profiles:
+      - build
     build:
       context: docker/sbt-rpmbuild
       args:


### PR DESCRIPTION
通常使用しないものなのに、build/runされるのは面倒なため

docker-compose prifiles を使用


## 参考
- https://github.com/lerna-stack/lerna-sample-payment-app/pull/13
- [Compose でのプロファイル利用 | Docker ドキュメント](https://matsuand.github.io/docs.docker.jp.onthefly/compose/profiles/)