### PR TITLE
test: テスト時 裏で cassandra に接続することを回避

### DIFF
--- a/app/application/src/test/resources/application-test.conf
+++ b/app/application/src/test/resources/application-test.conf
@@ -7,3 +7,7 @@ myapp.application {
 akka.cluster.roles = [
   "replica-group-1"
 ]
+
+# reference.conf での定義によって cassandra へ接続することを回避する
+akka.persistence.journal.auto-start-journals = []
+akka.persistence.snapshot-store.auto-start-snapshot-stores = []

--- a/app/entrypoint/src/test/resources/application.conf
+++ b/app/entrypoint/src/test/resources/application.conf
@@ -5,3 +5,7 @@ myapp {
 akka.cluster.roles = [
   "replica-group-1",
 ]
+
+# app/application/src/main/resources/reference.conf での定義によって cassandra へ接続することを回避する
+akka.persistence.journal.auto-start-journals = []
+akka.persistence.snapshot-store.auto-start-snapshot-stores = []


### PR DESCRIPTION
もしかしたら、 reference.conf に `auto-start-journals` を書くことをやめたほうが良いかもしれない