### PR TITLE
リリースバージョンを使用する

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl \
     --show-error \
     --request 'GET' \
     --url 'http://127.0.0.1:9001/accounts/test33' \
-    --header 'X-Tenant-Id: tenant-a' \
+    --header 'X-Tenant-Id: tenant-a'
 ```
 
 #### 入金
@@ -113,7 +113,7 @@ curl \
     --show-error \
     --request 'POST' \
     --url "http://127.0.0.1:9001/accounts/test33/deposit?transactionId=$(date '+%s')&amount=600" \
-    --header 'X-Tenant-Id: tenant-a' \
+    --header 'X-Tenant-Id: tenant-a'
 ```
 
 #### 出金
@@ -131,7 +131,7 @@ curl \
     --show-error \
     --request 'POST' \
     --url "http://127.0.0.1:9001/accounts/test33/withdraw?transactionId=$(date '+%s')&amount=500" \
-    --header 'X-Tenant-Id: tenant-a' \
+    --header 'X-Tenant-Id: tenant-a'
 ```
 
 ## テストカバレッジ を取得する

--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,6 @@ ThisBuild / fork in Test := true
 // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき紛らわしいため
 ThisBuild / outputStrategy := Some(StdoutOutput)
 
-// TODO SNAPSHOT を使用しなくなったら SNAPSHOT用の resolver は削除すること
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
-
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)
   .aggregate(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val akkaEntityReplication    = "2.0.0"
-    val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
+    val lerna                    = "2.0.0"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "1.0.0+188-a673fe8d-SNAPSHOT"
+    val akkaEntityReplication    = "2.0.0"
     val lerna                    = "2.0.0-ab5c7912-SNAPSHOT"
     val akka                     = "2.6.12"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
- [Release v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/releases/tag/v2.0.0)
- [Release v2.0.0 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/releases/tag/v2.0.0)
- Sonatype snapshot repsotiroy を resolvers から削除する

## テスト

アプリケーションサーバを起動し、入金、出金、残高確認の API が動作していることを念のため確認しました。

```
$ curl \
    --silent \
    --show-error \
    --request 'POST' \
    --url "http://127.0.0.1:9001/accounts/test33/deposit?transactionId=$(date '+%s')&amount=600" \
    --header 'X-Tenant-Id: tenant-a'
600

$ curl \
    --silent \
    --show-error \
    --request 'POST' \
    --url "http://127.0.0.1:9001/accounts/test33/withdraw?transactionId=$(date '+%s')&amount=500" \
    --header 'X-Tenant-Id: tenant-a'
100

$ curl \
    --silent \
    --show-error \
    --request 'GET' \
    --url 'http://127.0.0.1:9001/accounts/test33' \
    --header 'X-Tenant-Id: tenant-a'
100
```
