### PR TITLE
2021.7.0 リリース

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 
 ## Unreleased
 
-## Version 0.0.0
+## Version 2021.7.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -192,3 +192,6 @@ RPM パッケージに含める内容はすべてコミット済みであるこ�
 RPM パッケージをビルドする前に、この条件が満たされていることを確認してください。
 
 - RPM パッケージのビルドには [CHANGELOG.md](./CHANGELOG.md) ファイルが必要です。
+
+## バージョン戦略
+[Calendar Versioning — CalVer](https://calver.org/) `YYYY.MM.MICRO` を使用します。

--- a/README.md
+++ b/README.md
@@ -195,3 +195,7 @@ RPM パッケージをビルドする前に、この条件が満たされてい�
 
 ## バージョン戦略
 [Calendar Versioning — CalVer](https://calver.org/) `YYYY.MM.MICRO` を使用します。
+
+## CHANGELOG
+
+特筆すべき変更点は [CHANGELOG.md](CHANGELOG.md) から確認できます。

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.util.Try
 
 ThisBuild / name := "myapp"
 ThisBuild / description := "description"
-ThisBuild / version := "1.0.0"
+ThisBuild / version := "2021.7.0"
 ThisBuild / organization := "organization"
 ThisBuild / scalaVersion := "2.13.6"
 ThisBuild / scalacOptions ++= Seq(


### PR DESCRIPTION
2021.7.0 をリリースします。

## 確認済

### バージョン番号の変更漏れありません
  ```
  $ git grep -iF '1.0.0'
  CHANGELOG.md:このファイルの書き方に関する推奨事項については、[Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を確認してください。
  ```

### SNAPSHOT jar を使用している箇所はありません
  ```
  $ git grep -iF 'snapshot'
  app/application/src/main/resources/reference.conf:  snapshot-store {
  app/application/src/main/resources/reference.conf:    auto-start-snapshot-stores = [
  app/application/src/main/resources/reference.conf:      "akka-entity-replication.raft.persistence.cassandra-tenant-a.snapshot",
  app/application/src/main/resources/reference.conf:      "akka-entity-replication.raft.persistence.cassandra-tenant-b.snapshot",
  app/application/src/main/resources/reference.conf:  snapshot {
  app/application/src/main/resources/reference.conf:    read-profile = "akka-entity-replication-snapshot-profile"
  app/application/src/main/resources/reference.conf:    write-profile = "akka-entity-replication-snapshot-profile"
  app/application/src/main/resources/reference.conf:    // Name of the keyspace to be used by the snapshot store
  app/application/src/main/resources/reference.conf:    keyspace = "entity_replication_snapshot"
  app/application/src/main/resources/reference.conf:    // Number load attempts when recovering from the latest snapshot fails yet older snapshot files are available.
  app/application/src/main/resources/reference.conf:    // But old snapshots should be ignored because akka-entity-replication uses only the latest snapshot.
  app/application/src/main/resources/reference.conf:  snapshot.keyspace = "entity_replication_snapshot_tenant_a"
  app/application/src/main/resources/reference.conf:  snapshot.keyspace = "entity_replication_snapshot_tenant_b"
  app/application/src/main/resources/reference.conf:    akka-entity-replication-snapshot-profile {
  app/application/src/main/resources/reference.conf:        // the snapshot store does not use any counters or collections
  app/application/src/main/scala/myapp/application/account/BankAccountApplicationImpl.scala:      .withRaftSnapshotPluginId(s"akka-entity-replication.raft.persistence.cassandra-${tenant.id}.snapshot")
  app/application/src/test/resources/application-test.conf:akka.persistence.snapshot-store.auto-start-snapshot-stores = []
  app/entrypoint/src/test/resources/application.conf:akka.persistence.snapshot-store.auto-start-snapshot-stores = []
  docker/cassandra/conf/cassandra.yaml:# Whether or not to take a snapshot before each compaction.  Be
  docker/cassandra/conf/cassandra.yaml:# snapshots for you.  Mostly useful if you're paranoid when there
  docker/cassandra/conf/cassandra.yaml:snapshot_before_compaction: false
  docker/cassandra/conf/cassandra.yaml:# Whether or not a snapshot is taken of the data before keyspace truncation
  docker/cassandra/conf/cassandra.yaml:auto_snapshot: true
  docker/cassandra/conf/cassandra.yaml:# (This can be much longer, because unless auto_snapshot is disabled
  docker/cassandra/conf/cassandra.yaml:# we need to flush first so we can snapshot before removing the data.)
  scripts/start-app-1.sh:-Dakka.persistence.cassandra.snapshot.keyspace-autocreate=true \
  scripts/start-app-1.sh:-Dakka.persistence.cassandra.snapshot.tables-autocreate=true \
  ```

## TODO (After merged)
- [ ] `main` ブランチから タグ `2021.7.0` を切る