### PR TITLE
🐞fix: Overwrites akka.persistence.cassandra.query.read-profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 
 - RDBMS を介して連携されるデータを Entity にインポートするサンプル実装を追加しました [PR#19](https://github.com/lerna-stack/lerna-sample-account-app/pull/19)
 
+### Fixed
+
+- Cassandra からイベントなどを読み込む際のプロファイルが書き込みの際に使われるプロファイルとは違うものになっていた問題を修正しました [PR#21](https://github.com/lerna-stack/lerna-sample-account-app/pull/21)
+
 ## Version 2021.7.0
 
 - Initial release

--- a/app/application/src/main/resources/reference.conf
+++ b/app/application/src/main/resources/reference.conf
@@ -94,6 +94,12 @@ akka-entity-replication.raft.persistence.cassandra = ${akka.persistence.cassandr
     keyspace = "entity_replication"
   }
 
+  query {
+    // Profile to use.
+    // See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/ for overriding any settings
+    read-profile = "akka-entity-replication-profile"
+  }
+
   snapshot {
 
     // Profile to use.
@@ -154,6 +160,12 @@ akka-entity-replication.eventsourced.persistence.cassandra = ${akka.persistence.
       // bank-account-tagging takes events which mixins BankAccount$DomainEvent
       "myapp.application.account.BankAccountBehavior$DomainEvent" = bank-account-tagging
     }
+  }
+
+  query {
+    // Profile to use.
+    // See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/ for overriding any settings
+    read-profile = "akka-entity-replication-profile"
   }
 }
 


### PR DESCRIPTION
`akka.persistence.cassandra.query` には Cassandra のイベントなどを読み込んだりするときに利用するプロファイルを設定する `read-profile` という設定項目があります。デフォルトでは `akka-persistence-cassandra-profile` が設定されており、このプロファイルは Journal に書き込むときに使われる `akka-entity-replication-profile` とは異なるものです。

> ```
>     read-profile = "akka-persistence-cassandra-profile"
> ```
> **[akka-persistence-cassandra/reference.conf at v1.0.1 · akka/akka-persistence-cassandra](https://github.com/akka/akka-persistence-cassandra/blob/v1.0.1/core/src/main/resources/reference.conf#L210)**

整合性レベルなどをイベントの書き込みと合わせるため、`akka.persistence.cassandra` の設定を継承した設定項目について、`query.read-profile` を上書きで `akka-entity-replication-profile` に設定します。

## 動作確認

Cassandra Driver と akka-persistence-cassandra のログレベルを DEBUG にして使われる profile 名が出力されないか確認しましたが、ログからは profile 名を確認できませんでした。

そこで次のように不正な consistency level を設定した profile を作成し、`akka-entity-replication.raft.persistence.cassandra.query.read-profile` と `akka-entity-replication.eventsourced.persistence.cassandra.query.read-profile` を一つずつ `dummy-profile` に変更してどのような動作になるのか確認しました。

```
    dummy-profile {
      basic.request {
        // Important: akka-entity-replication recommends quorum based consistency level to remain data consistency
        consistency = "INVALID"
        // the journal does not use any counters or collections
        default-idempotence = true
      }
    }
```

**`akka-entity-replication.raft.persistence.cassandra.query.read-profile = "dummy-profile"`  を設定した場合：**

次のエラーログが出力されました。

```
2021-09-07 19:23:09.753 ERROR   akka.actor.RepointableActorRef  -       -       -       Error during preStart in [akka.persistence.cassandra.query.EventsByPersistenceIdStage$$anon$1-asyncReplayMessages]: null
java.lang.NullPointerException: null
        at com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry.nameToCode(DefaultConsistencyLevelRegistry.java:46)
        at com.datastax.oss.driver.internal.core.cql.Conversions.toMessage(Conversions.java:124)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.<init>(CqlRequestHandler.java:173)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestAsyncProcessor.process(CqlRequestAsyncProcessor.java:44)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestAsyncProcessor.process(CqlRequestAsyncProcessor.java:29)
        at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:230)
        at com.datastax.oss.driver.api.core.cql.AsyncCqlSession.executeAsync(AsyncCqlSession.java:41)
        at akka.persistence.cassandra.query.EventsByPersistenceIdStage$EventsByPersistenceIdSession.executeStatement(EventsByPersistenceIdStage.scala:83)
        at akka.persistence.cassandra.query.EventsByPersistenceIdStage$EventsByPersistenceIdSession.highestDeletedSequenceNumber(EventsByPersistenceIdStage.scala:79)
        at akka.persistence.cassandra.query.EventsByPersistenceIdStage$$anon$1.preStart(EventsByPersistenceIdStage.scala:249)
        at akka.stream.impl.fusing.GraphInterpreter.init(GraphInterpreter.scala:306)
        at akka.stream.impl.fusing.GraphInterpreterShell.init(ActorGraphInterpreter.scala:594)
        at akka.stream.impl.fusing.ActorGraphInterpreter.tryInit(ActorGraphInterpreter.scala:702)
        at akka.stream.impl.fusing.ActorGraphInterpreter.preStart(ActorGraphInterpreter.scala:751)
        at akka.actor.Actor.aroundPreStart(Actor.scala:548)
        at akka.actor.Actor.aroundPreStart$(Actor.scala:548)
        at akka.stream.impl.fusing.ActorGraphInterpreter.aroundPreStart(ActorGraphInterpreter.scala:691)
        at akka.actor.ActorCell.create(ActorCell.scala:641)
        at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:513)
        at akka.actor.ActorCell.systemInvoke(ActorCell.scala:535)
        at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:295)
        at akka.dispatch.Mailbox.run(Mailbox.scala:230)
        at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

例外が発生した箇所：
> ```
>     return NAME_TO_CODE.get(name);
> ```
> **[java-driver/DefaultConsistencyLevelRegistry.java at 4.6.1 · datastax/java-driver](https://github.com/datastax/java-driver/blob/4.6.1/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultConsistencyLevelRegistry.java#L46)**

確証は得られなかったですが、`consistency = "INVALID"` を読み込んだことでこの例外が発生していると予想できます。
設定項目 `akka-entity-replication.raft.persistence.cassandra.query.read-profile` が有効になっていると言えそうです。

**`akka-entity-replication.eventsourced.persistence.cassandra.query.read-profile = "dummy-profile"`  を設定した場合：**

`akka-entity-replication.raft.persistence.cassandra.query.read-profile` は `akka-entity-replication-profile` に戻してあります。

次のエラーログが出力されました。

```
2021-09-07 19:29:04.112 ERROR   akka.actor.RepointableActorRef  -       -       -       Error during preStart in [akka.persistence.cassandra.query.EventsByTagStage$$anon$2-futureFlattenSource]: null
java.lang.NullPointerException: null
        at com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry.nameToCode(DefaultConsistencyLevelRegistry.java:46)
        at com.datastax.oss.driver.internal.core.cql.Conversions.toMessage(Conversions.java:124)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.<init>(CqlRequestHandler.java:173)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestAsyncProcessor.process(CqlRequestAsyncProcessor.java:44)
        at com.datastax.oss.driver.internal.core.cql.CqlRequestAsyncProcessor.process(CqlRequestAsyncProcessor.java:29)
        at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:230)
        at com.datastax.oss.driver.api.core.cql.AsyncCqlSession.executeAsync(AsyncCqlSession.java:41)
        at akka.persistence.cassandra.query.EventsByTagStage$TagStageSession.selectEventsForBucket(EventsByTagStage.scala:95)
        at akka.persistence.cassandra.query.EventsByTagStage$$anon$2.query(EventsByTagStage.scala:519)
        at akka.persistence.cassandra.query.EventsByTagStage$$anon$2.preStart(EventsByTagStage.scala:408)
        at akka.stream.impl.fusing.GraphInterpreter.init(GraphInterpreter.scala:306)
        at akka.stream.impl.fusing.GraphInterpreterShell.init(ActorGraphInterpreter.scala:594)
        at akka.stream.impl.fusing.ActorGraphInterpreter.tryInit(ActorGraphInterpreter.scala:702)
        at akka.stream.impl.fusing.ActorGraphInterpreter.finishShellRegistration(ActorGraphInterpreter.scala:745)
        at akka.stream.impl.fusing.ActorGraphInterpreter.akka$stream$impl$fusing$ActorGraphInterpreter$$shortCircuitBatch(ActorGraphInterpreter.scala:763)
        at akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(ActorGraphInterpreter.scala:789)
        at akka.actor.Actor.aroundReceive(Actor.scala:537)
        at akka.actor.Actor.aroundReceive$(Actor.scala:535)
        at akka.stream.impl.fusing.ActorGraphInterpreter.aroundReceive(ActorGraphInterpreter.scala:691)
        at akka.actor.ActorCell.receiveMessage(ActorCell.scala:577)
        at akka.actor.ActorCell.invoke(ActorCell.scala:547)
        at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
        at akka.dispatch.Mailbox.run(Mailbox.scala:231)
        at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

例外が発生した箇所：
> ```
>     return NAME_TO_CODE.get(name);
> ```
> **[java-driver/DefaultConsistencyLevelRegistry.java at 4.6.1 · datastax/java-driver](https://github.com/datastax/java-driver/blob/4.6.1/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultConsistencyLevelRegistry.java#L46)**

こちらも同じく確証は得られなかったですが、`consistency = "INVALID"` を読み込んだことでこの例外が発生していると予想できます。
設定項目 `akka-entity-replication.eventsourced.persistence.cassandra.query.read-profile` が有効になっていると言えそうです。