### PR TITLE
ApplicationRoute をテストする

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ curl \
 ```
 
 #### 入金
-- method: `GET`
+- method: `POST`
 - path: `/accounts/${accountNo}/deposit`
 - (query) parameters
     - `transactionId` (string)
@@ -117,7 +117,7 @@ curl \
 ```
 
 #### 出金
-- method: `GET`
+- method: `POST`
 - path: `/accounts/${accountNo}/withdraw`
 - (query) parameters
     - `transactionId` (string)

--- a/app/adapter/src/main/scala/myapp/adapter/account/BankAccountApplication.scala
+++ b/app/adapter/src/main/scala/myapp/adapter/account/BankAccountApplication.scala
@@ -5,17 +5,46 @@ import myapp.utility.AppRequestContext
 import scala.concurrent.Future
 
 trait BankAccountApplication {
+
+  /** 指定口座の残高を取得する。
+    *
+    * 口座は、口座番号([[AccountNo]])とテナント([[myapp.utility.tenant.AppTenant]])で一意に決定される。
+    *
+    * @param accountNo 口座番号
+    * @return 残高を格納した [[Future]] を返す
+    */
   def fetchBalance(accountNo: AccountNo)(implicit appRequestContext: AppRequestContext): Future[BigInt]
 
+  /** 指定口座に指定金額を入金する。
+    *
+    * 口座は、口座番号([[AccountNo]])とテナント([[myapp.utility.tenant.AppTenant]])で一意に決定される。
+    * `transactionId` により冪等性が保証される。
+    *
+    * @param accountNo 口座番号
+    * @param transactionId トランザクションID
+    * @param amount 入金金額
+    * @return 入金後の残高を格納した [[Future]] を返す
+    */
   def deposit(
       accountNo: AccountNo,
       transactionId: TransactionId,
       amount: BigInt,
   )(implicit appRequestContext: AppRequestContext): Future[BigInt]
 
+  /** 指定口座から指定金額を出金する。
+    *
+    * 口座は、口座番号([[AccountNo]])とテナント([[myapp.utility.tenant.AppTenant]])で一意に決定される。
+    * `transactionId` により冪等性が保証される。
+    *
+    * @param accountNo 口座番号
+    * @param transactionId トランザクションID
+    * @param amount 出金金額
+    * @return 出金後の残高を格納した [[Future]] を返す
+    */
   def withdraw(
       accountNo: AccountNo,
       transactionId: TransactionId,
       amount: BigInt,
   )(implicit appRequestContext: AppRequestContext): Future[BigInt]
+
 }

--- a/app/presentation/src/test/scala/myapp/presentation/application/ApplicationRouteSpec.scala
+++ b/app/presentation/src/test/scala/myapp/presentation/application/ApplicationRouteSpec.scala
@@ -1,36 +1,42 @@
 package myapp.presentation.application
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ HttpHeader, StatusCodes }
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.{ MalformedHeaderRejection, MissingHeaderRejection }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import lerna.testkit.airframe.DISessionSupport
 import myapp.adapter.account.{ AccountNo, BankAccountApplication, TransactionId }
 import myapp.presentation.PresentationDIDesign
 import myapp.utility.AppRequestContext
 import myapp.utility.scalatest.StandardSpec
+import myapp.utility.tenant.{ AppTenant, TenantA, TenantB }
+import org.scalamock.function._
+import org.scalamock.scalatest.MockFactory
 import wvlet.airframe.Design
 
 import scala.concurrent.Future
 
-@SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))
-class ApplicationRouteSpec extends StandardSpec with ScalatestRouteTest with DISessionSupport {
+@SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride", "org.wartremover.warts.IsInstanceOf"))
+class ApplicationRouteSpec extends StandardSpec with ScalatestRouteTest with MockFactory with DISessionSupport {
   override protected val diDesign: Design = PresentationDIDesign.presentationDesign
-    .bind[BankAccountApplication].toInstance(new BankAccountApplication {
-      override def fetchBalance(
-          accountNo: AccountNo,
-      )(implicit appRequestContext: AppRequestContext): Future[BigInt] = ???
-      override def deposit(
-          accountNo: AccountNo,
-          transactionId: TransactionId,
-          amount: BigInt,
-      )(implicit appRequestContext: AppRequestContext): Future[BigInt] = ???
-      override def withdraw(
-          accountNo: AccountNo,
-          transactionId: TransactionId,
-          amount: BigInt,
-      )(implicit appRequestContext: AppRequestContext): Future[BigInt] = ???
-    })
+    .bind[BankAccountApplication].toInstance(mock[BankAccountApplication])
 
   val route: ApplicationRoute = diSession.build[ApplicationRoute]
+
+  private val accountService: BankAccountApplication = diSession.build[BankAccountApplication]
+  private val fetchBalance: MockFunction2[AccountNo, AppRequestContext, Future[BigInt]] =
+    accountService.fetchBalance(_)(_)
+  private val deposit: MockFunction4[AccountNo, TransactionId, BigInt, AppRequestContext, Future[BigInt]] =
+    accountService.deposit(_, _, _)(_)
+  private val withdraw: MockFunction4[AccountNo, TransactionId, BigInt, AppRequestContext, Future[BigInt]] =
+    accountService.withdraw(_, _, _)(_)
+
+  private val invalidTenant = new AppTenant {
+    override def id: String = "invalid"
+  }
+  private def tenantHeader(tenant: AppTenant): HttpHeader = {
+    RawHeader("X-Tenant-Id", tenant.id)
+  }
 
   "ApplicationRoute" should {
 
@@ -41,6 +47,144 @@ class ApplicationRouteSpec extends StandardSpec with ScalatestRouteTest with DIS
           responseAs[String] === "OK"
         }
       }
+    }
+
+    "return the account balance of the given account" in {
+
+      fetchBalance
+        .expects(where { (accountNo, context) =>
+          accountNo === AccountNo("123-456") &&
+          context.tenant === TenantA
+        }).returns(Future.successful(100))
+
+      fetchBalance
+        .expects(where { (accountNo, context) =>
+          accountNo === AccountNo("123-456") &&
+          context.tenant === TenantB
+        }).returns(Future.successful(200))
+
+      Get("/accounts/123-456").withHeaders(tenantHeader(TenantA)) ~> route.route ~> check {
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "100\n")
+      }
+
+      Get("/accounts/123-456").withHeaders(tenantHeader(TenantB)) ~> route.route ~> check {
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "200\n")
+      }
+
+    }
+
+    "not return the account balance with an invalid tenant" in {
+
+      Get("/accounts/123-456").withHeaders(tenantHeader(invalidTenant)) ~> route.route ~> check {
+        expect(rejection.isInstanceOf[MalformedHeaderRejection])
+      }
+
+    }
+
+    "not return the account balance without a tenant" in {
+
+      Get("/accounts/123-456") ~> route.route ~> check {
+        expect(rejection.isInstanceOf[MissingHeaderRejection])
+      }
+
+    }
+
+    "deposit the given amount into the account and then return the account balance" in {
+
+      deposit
+        .expects(where { (accountNo, _, _, context) =>
+          accountNo === AccountNo("123-456") &&
+          context.tenant === TenantA
+        }).onCall { (_, _, amount, _) =>
+          Future.successful(100 + amount)
+        }
+
+      Post("/accounts/123-456/deposit?transactionId=deposit1&amount=200")
+        .withHeaders(tenantHeader(TenantA)) ~> route.route ~> check {
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "300\n")
+      }
+
+      deposit
+        .expects(where { (accountNo, _, _, context) =>
+          accountNo === AccountNo("123-456") &&
+          context.tenant === TenantB
+        }).onCall { (_, _, amount, _) =>
+          Future.successful(200 + amount)
+        }
+
+      Post("/accounts/123-456/deposit?transactionId=deposit1&amount=300")
+        .withHeaders(tenantHeader(TenantB)) ~> route.route ~> check {
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "500\n")
+      }
+
+    }
+
+    "not deposit with an invalid tenant" in {
+
+      Post("/accounts/123-456/deposit?transactionId=deposit1&amount=100")
+        .withHeaders(tenantHeader(invalidTenant)) ~> route.route ~> check {
+        expect(rejection.isInstanceOf[MalformedHeaderRejection])
+      }
+
+    }
+
+    "not deposit without a tenant" in {
+
+      Post("/accounts/123-456/deposit?transactionId=deposit1&amount=100") ~> route.route ~> check {
+        expect(rejection.isInstanceOf[MissingHeaderRejection])
+      }
+
+    }
+
+    "withdraw the given amount from the account and then return the account balance" in {
+
+      withdraw
+        .expects(where { (accountNo, _, amount, context) =>
+          accountNo === AccountNo("123-456") &&
+          context.tenant === TenantA &&
+          amount === BigInt(40)
+        }).returns(Future.successful(60))
+
+      Post("/accounts/123-456/withdraw?transactionId=withdraw1&amount=40")
+        .withHeaders(tenantHeader(TenantA)) ~> route.route ~> check {
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "60\n")
+      }
+
+      withdraw
+        .expects(where { (accountNo, _, ammount, context) =>
+          accountNo === AccountNo("123-456") &&
+          context.tenant === TenantB &&
+          ammount === BigInt(120)
+        }).returns(Future.successful(80))
+
+      Post("/accounts/123-456/withdraw?transactionId=withdraw1&amount=120")
+        .withHeaders(tenantHeader(TenantB)) ~> route.route ~> check {
+        expect(status === StatusCodes.OK)
+        expect(responseAs[String] === "80\n")
+      }
+
+    }
+
+    "not withdraw with an invalid tenant" in {
+
+      Post("/accounts/123-456/withdraw?transactionId=withdraw1&amount=100")
+        .withHeaders(tenantHeader(invalidTenant)) ~> route.route ~> check {
+        expect(rejection.isInstanceOf[MalformedHeaderRejection])
+      }
+
+    }
+
+    "not withdraw without a tenant" in {
+
+      Post("/accounts/123-456/withdraw?transactionId=withdraw1&amount=100") ~> route.route ~> check {
+        expect(rejection.isInstanceOf[MissingHeaderRejection])
+      }
+
     }
 
   }


### PR DESCRIPTION
* `BankAccountApplication` の仕様を scaladoc に記述します
* `ApplicationRoute` の 残高確認, 入金, 出金 をテストします
* README に記載されている 入金, 出金 の HTTP メソッド名を修正します