### PR TITLE
ProjectionでQuery側DBに取引内容を保存できるように変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 
 ## Unreleased
 
+### Changed
+- 入出金明細出力の実装に向けてQuery側DBを更新できるよう変更 [PR#32](https://github.com/lerna-stack/lerna-sample-account-app/pull/32)
+  - `Deposited`, `Withdrew`, `Refunded` イベント発生時に取引ID、イベント名と取引額を保存します
 
 ## [v2021.10.0] - 2021-10-22
 [v2021.10.0]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2021.7.0...v2021.10.0

--- a/app/application/src/main/scala/myapp/application/ApplicationDIDesign.scala
+++ b/app/application/src/main/scala/myapp/application/ApplicationDIDesign.scala
@@ -2,6 +2,7 @@ package myapp.application
 
 import myapp.adapter.account.{ BankAccountApplication, RemittanceApplication }
 import myapp.application.account.{ BankAccountApplicationImpl, RemittanceApplicationImpl }
+import myapp.application.projection.transaction.{ TransactionRepository, TransactionRepositoryImpl }
 import wvlet.airframe.{ newDesign, Design }
 
 /** Application プロジェクト内のコンポーネントの [[wvlet.airframe.Design]] を定義する
@@ -17,6 +18,7 @@ import wvlet.airframe.{ newDesign, Design }
 object ApplicationDIDesign {
   @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity"))
   val applicationDesign: Design = newDesign
+    .bind[TransactionRepository].to[TransactionRepositoryImpl]
     .bind[BankAccountApplication].to[BankAccountApplicationImpl]
     .bind[RemittanceApplication].to[RemittanceApplicationImpl]
 }

--- a/app/application/src/main/scala/myapp/application/projection/AppEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/AppEventHandler.scala
@@ -24,6 +24,8 @@ trait AppEventHandler[E] extends SlickHandler[EventEnvelope[E]] {
 
   import AppEventHandler._
 
+  protected def eventTag: AggregateEventTag[E]
+
   def createBehavior(setup: BehaviorSetup): Behavior[ProjectionBehavior.Command] = {
     val sourceProvider: SourceProvider[Offset, EventEnvelope[E]] =
       EventSourcedProvider.eventsByTag[E](
@@ -47,7 +49,4 @@ trait AppEventHandler[E] extends SlickHandler[EventEnvelope[E]] {
       handler = () => this,
     )
   }
-
-  protected def eventTag: AggregateEventTag[E]
-
 }

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -33,13 +33,13 @@ class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: Tran
     envelope.event match {
       case Deposited(transactionId, amount) =>
         logger.info("Deposited(transactionId: {}, amount: {})", transactionId, amount)
-        repository.save(Transaction(transactionId.value, "Deposited", amount.toInt))
+        repository.save(Transaction(transactionId.value, "Deposited", amount))
       case BalanceExceeded(transactionId) =>
         logger.info("BalanceExceeded(transactionId: {})", transactionId)
         DBIO.successful(Done)
       case Withdrew(transactionId, amount) =>
         logger.info("Withdrew(transactionId: {}, amount: {})", transactionId, amount)
-        DBIO.successful(Done)
+        repository.save(Transaction(transactionId.value, "Withdrew", amount))
       case BalanceShorted(transactionId) =>
         logger.info("BalanceShorted(transactionId: {})", transactionId)
         DBIO.successful(Done)
@@ -50,7 +50,7 @@ class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: Tran
           withdrawalTransactionId,
           amount,
         )
-        DBIO.successful(Done)
+        repository.save(Transaction(transactionId.value, "Refunded", amount))
       case InvalidRefundRequested(transactionId, withdrawalTransactionId, amount) =>
         logger.info(
           "InvalidRefundRequested(transactionId: {}, withdrawalTransactionId: {}, amount: {}",

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -14,6 +14,9 @@ class BankTransactionEventHandler(repository: TransactionRepository)
     extends AppEventHandler[BankAccountBehavior.DomainEvent]
     with AppLogging {
 
+  override protected def eventTag: AggregateEventTag[BankAccountBehavior.DomainEvent] =
+    BankAccountEventAdapter.BankAccountTransactionEventTag
+
   override def process(envelope: EventEnvelope[BankAccountBehavior.DomainEvent]): DBIO[Done] = {
     implicit val requestContext: AppRequestContext = envelope.event.appRequestContext
 
@@ -48,7 +51,4 @@ class BankTransactionEventHandler(repository: TransactionRepository)
         DBIO.successful(Done)
     }
   }
-
-  override protected def eventTag: AggregateEventTag[BankAccountBehavior.DomainEvent] =
-    BankAccountEventAdapter.BankAccountTransactionEventTag
 }

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -1,7 +1,6 @@
 package myapp.application.projection.transaction
 
 import akka.Done
-import akka.actor.typed.ActorSystem
 import akka.projection.eventsourced.EventEnvelope
 import lerna.log.AppLogging
 import myapp.application.account.BankAccountBehavior._
@@ -11,11 +10,9 @@ import myapp.application.projection.AppEventHandler
 import myapp.utility.AppRequestContext
 import slick.dbio.DBIO
 
-class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: TransactionRepository)
+class BankTransactionEventHandler(repository: TransactionRepository)
     extends AppEventHandler[BankAccountBehavior.DomainEvent]
     with AppLogging {
-
-  implicit val ec = system.executionContext
 
   override def process(envelope: EventEnvelope[BankAccountBehavior.DomainEvent]): DBIO[Done] = {
     implicit val requestContext: AppRequestContext = envelope.event.appRequestContext

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -34,7 +34,6 @@ class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: Tran
       case Deposited(transactionId, amount) =>
         logger.info("Deposited(transactionId: {}, amount: {})", transactionId, amount)
         repository.save(Transaction(transactionId.value, "Deposited", amount.toInt))
-        DBIO.successful(Done)
       case BalanceExceeded(transactionId) =>
         logger.info("BalanceExceeded(transactionId: {})", transactionId)
         DBIO.successful(Done)

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -20,7 +20,8 @@ import slick.dbio.DBIO
 import scala.concurrent.ExecutionContext
 
 class BankTransactionEventHandler(repository: TransactionRepository)(implicit ec: ExecutionContext)
-  extends AppEventHandler[BankAccountBehavior.DomainEvent] with AppLogging {
+    extends AppEventHandler[BankAccountBehavior.DomainEvent]
+    with AppLogging {
 
   override protected def eventTag: AggregateEventTag[BankAccountBehavior.DomainEvent] =
     BankAccountEventAdapter.BankAccountTransactionEventTag

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -1,6 +1,7 @@
 package myapp.application.projection.transaction
 
 import akka.Done
+import akka.actor.typed.ActorSystem
 import akka.projection.eventsourced.EventEnvelope
 import lerna.log.AppLogging
 import myapp.application.account.{ BankAccountBehavior, BankAccountEventAdapter }
@@ -17,11 +18,11 @@ import myapp.application.projection.AppEventHandler
 import myapp.utility.AppRequestContext
 import slick.dbio.DBIO
 
-import scala.concurrent.ExecutionContext
-
-class BankTransactionEventHandler(repository: TransactionRepository)(implicit ec: ExecutionContext)
+class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: TransactionRepository)
     extends AppEventHandler[BankAccountBehavior.DomainEvent]
     with AppLogging {
+
+  implicit val ec = system.executionContext
 
   override protected def eventTag: AggregateEventTag[BankAccountBehavior.DomainEvent] =
     BankAccountEventAdapter.BankAccountTransactionEventTag

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -17,7 +17,10 @@ import myapp.application.projection.AppEventHandler
 import myapp.utility.AppRequestContext
 import slick.dbio.DBIO
 
-class BankTransactionEventHandler extends AppEventHandler[BankAccountBehavior.DomainEvent] with AppLogging {
+import scala.concurrent.ExecutionContext
+
+class BankTransactionEventHandler(repository: TransactionRepository)(implicit ec: ExecutionContext)
+  extends AppEventHandler[BankAccountBehavior.DomainEvent] with AppLogging {
 
   override protected def eventTag: AggregateEventTag[BankAccountBehavior.DomainEvent] =
     BankAccountEventAdapter.BankAccountTransactionEventTag
@@ -28,6 +31,7 @@ class BankTransactionEventHandler extends AppEventHandler[BankAccountBehavior.Do
     envelope.event match {
       case Deposited(transactionId, amount) =>
         logger.info("Deposited(transactionId: {}, amount: {})", transactionId, amount)
+        repository.save(Transaction(transactionId.value, "Deposited", amount.toInt))
         DBIO.successful(Done)
       case BalanceExceeded(transactionId) =>
         logger.info("BalanceExceeded(transactionId: {})", transactionId)

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -23,13 +23,13 @@ class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: Tran
     envelope.event match {
       case Deposited(transactionId, amount) =>
         logger.info("Deposited(transactionId: {}, amount: {})", transactionId, amount)
-        repository.save(Transaction(transactionId.value, TransactionEventType.Deposited, amount))
+        repository.save(Transaction(transactionId, TransactionEventType.Deposited, amount))
       case BalanceExceeded(transactionId) =>
         logger.info("BalanceExceeded(transactionId: {})", transactionId)
         DBIO.successful(Done)
       case Withdrew(transactionId, amount) =>
         logger.info("Withdrew(transactionId: {}, amount: {})", transactionId, amount)
-        repository.save(Transaction(transactionId.value, TransactionEventType.Withdrew, amount))
+        repository.save(Transaction(transactionId, TransactionEventType.Withdrew, amount))
       case BalanceShorted(transactionId) =>
         logger.info("BalanceShorted(transactionId: {})", transactionId)
         DBIO.successful(Done)
@@ -40,7 +40,7 @@ class BankTransactionEventHandler(system: ActorSystem[Nothing], repository: Tran
           withdrawalTransactionId,
           amount,
         )
-        repository.save(Transaction(transactionId.value, TransactionEventType.Refunded, amount))
+        repository.save(Transaction(transactionId, TransactionEventType.Refunded, amount))
       case InvalidRefundRequested(transactionId, withdrawalTransactionId, amount) =>
         logger.info(
           "InvalidRefundRequested(transactionId: {}, withdrawalTransactionId: {}, amount: {}",

--- a/app/application/src/main/scala/myapp/application/projection/transaction/Transaction.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/Transaction.scala
@@ -1,3 +1,5 @@
 package myapp.application.projection.transaction
 
-final case class Transaction(transactionId: String, eventType: TransactionEventType.Value, amount: BigInt)
+import myapp.adapter.account.TransactionId
+
+final case class Transaction(transactionId: TransactionId, eventType: TransactionEventType.Value, amount: BigInt)

--- a/app/application/src/main/scala/myapp/application/projection/transaction/Transaction.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/Transaction.scala
@@ -1,5 +1,6 @@
 package myapp.application.projection.transaction
 
 import myapp.adapter.account.TransactionId
+import myapp.application.projection.transaction.TransactionEventType.TransactionEventType
 
-final case class Transaction(transactionId: TransactionId, eventType: TransactionEventType.Value, amount: BigInt)
+final case class Transaction(transactionId: TransactionId, eventType: TransactionEventType, amount: BigInt)

--- a/app/application/src/main/scala/myapp/application/projection/transaction/Transaction.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/Transaction.scala
@@ -1,0 +1,3 @@
+package myapp.application.projection.transaction
+
+final case class Transaction(transactionId: String, eventType: TransactionEventType.Value, amount: BigInt)

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionEventType.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionEventType.scala
@@ -1,0 +1,7 @@
+package myapp.application.projection.transaction
+
+object TransactionEventType extends Enumeration {
+  val Deposited = Value("Deposited")
+  val Withdrew  = Value("Withdrew")
+  val Refunded  = Value("Refunded")
+}

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionEventType.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionEventType.scala
@@ -1,6 +1,7 @@
 package myapp.application.projection.transaction
 
 object TransactionEventType extends Enumeration {
+  type TransactionEventType = Value
   val Deposited = Value("Deposited")
   val Withdrew  = Value("Withdrew")
   val Refunded  = Value("Refunded")

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -2,22 +2,19 @@ package myapp.application.projection.transaction
 
 import akka.Done
 import myapp.readmodel.schema.Tables
-import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
-import slick.jdbc.JdbcProfile
 
 import scala.concurrent.ExecutionContext
 
-final case class Transaction(transactionId: String, eventName: String, amount: Int)
+final case class Transaction(transactionId: String, eventName: String, amount: Long)
 
 trait TransactionRepository {
   def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done]
 }
 
-class TransactionRepositoryImpl(val table: Tables, dbConfig: DatabaseConfig[JdbcProfile])
-    extends TransactionRepository {
-  import dbConfig.profile.api._
-  import table._
+class TransactionRepositoryImpl(tables: Tables) extends TransactionRepository {
+  import tables._
+  import tables.profile.api._
   override def save(transaction: Transaction)(implicit ec: ExecutionContext) = {
     TransactionStore
       .insertOrUpdate(TransactionStoreRow(transaction.transactionId, transaction.eventName, transaction.amount))

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -6,8 +6,6 @@ import slick.dbio.DBIO
 
 import scala.concurrent.ExecutionContext
 
-final case class Transaction(transactionId: String, eventName: String, amount: BigInt)
-
 trait TransactionRepository {
   def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done]
 }
@@ -18,7 +16,7 @@ class TransactionRepositoryImpl(tables: Tables) extends TransactionRepository {
   override def save(transaction: Transaction)(implicit ec: ExecutionContext): slick.dbio.DBIO[Done] = {
     (TransactionStore += TransactionStoreRow(
       transaction.transactionId,
-      transaction.eventName,
+      transaction.eventType.toString,
       transaction.amount.longValue,
     ))
       .map(_ => Done)

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -1,19 +1,19 @@
 package myapp.application.projection.transaction
 
 import akka.Done
+import akka.actor.typed.ActorSystem
 import myapp.readmodel.schema.Tables
 import slick.dbio.DBIO
 
-import scala.concurrent.ExecutionContext
-
 trait TransactionRepository {
-  def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done]
+  def save(transaction: Transaction): DBIO[Done]
 }
 
-class TransactionRepositoryImpl(tables: Tables) extends TransactionRepository {
+class TransactionRepositoryImpl(tables: Tables, system: ActorSystem[Nothing]) extends TransactionRepository {
+  import system.executionContext
   import tables._
   import tables.profile.api._
-  override def save(transaction: Transaction)(implicit ec: ExecutionContext): slick.dbio.DBIO[Done] = {
+  override def save(transaction: Transaction): slick.dbio.DBIO[Done] = {
     (TransactionStore += TransactionStoreRow(
       transaction.transactionId.value,
       transaction.eventType.toString,

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -15,7 +15,7 @@ class TransactionRepositoryImpl(tables: Tables) extends TransactionRepository {
   import tables.profile.api._
   override def save(transaction: Transaction)(implicit ec: ExecutionContext): slick.dbio.DBIO[Done] = {
     (TransactionStore += TransactionStoreRow(
-      transaction.transactionId,
+      transaction.transactionId.value,
       transaction.eventType.toString,
       transaction.amount.longValue,
     ))

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -16,10 +16,11 @@ class TransactionRepositoryImpl(tables: Tables) extends TransactionRepository {
   import tables._
   import tables.profile.api._
   override def save(transaction: Transaction)(implicit ec: ExecutionContext): slick.dbio.DBIO[Done] = {
-    TransactionStore
-      .insertOrUpdate(
-        TransactionStoreRow(transaction.transactionId, transaction.eventName, transaction.amount.longValue),
-      )
+    (TransactionStore += TransactionStoreRow(
+      transaction.transactionId,
+      transaction.eventName,
+      transaction.amount.longValue,
+    ))
       .map(_ => Done)
   }
 }

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -6,7 +6,7 @@ import slick.dbio.DBIO
 
 import scala.concurrent.ExecutionContext
 
-final case class Transaction(transactionId: String, eventName: String, amount: Long)
+final case class Transaction(transactionId: String, eventName: String, amount: BigInt)
 
 trait TransactionRepository {
   def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done]
@@ -15,9 +15,11 @@ trait TransactionRepository {
 class TransactionRepositoryImpl(tables: Tables) extends TransactionRepository {
   import tables._
   import tables.profile.api._
-  override def save(transaction: Transaction)(implicit ec: ExecutionContext) = {
+  override def save(transaction: Transaction)(implicit ec: ExecutionContext): slick.dbio.DBIO[Done] = {
     TransactionStore
-      .insertOrUpdate(TransactionStoreRow(transaction.transactionId, transaction.eventName, transaction.amount))
+      .insertOrUpdate(
+        TransactionStoreRow(transaction.transactionId, transaction.eventName, transaction.amount.longValue),
+      )
       .map(_ => Done)
   }
 }

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -5,7 +5,7 @@ import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
 import slick.jdbc.JdbcProfile
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 case class Transaction(transactionId: String, eventName: String, amount: Int)
 
@@ -35,4 +35,3 @@ class TransactionRepositoryImpl(val dbConfig: DatabaseConfig[JdbcProfile]) exten
     def amount = column[Int]("AMOUNT")
   }
 }
-

--- a/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/TransactionRepository.scala
@@ -1,0 +1,38 @@
+package myapp.application.projection.transaction
+
+import akka.Done
+import slick.basic.DatabaseConfig
+import slick.dbio.DBIO
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class Transaction(transactionId: String, eventName: String, amount: Int)
+
+trait TransactionRepository {
+  def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done]
+}
+
+class TransactionRepositoryImpl(val dbConfig: DatabaseConfig[JdbcProfile]) extends TransactionRepository {
+
+  import dbConfig.profile.api._
+
+  private val transactionsTable = TableQuery[TransactionsTable]
+
+  override def save(transaction: Transaction)(implicit ec: ExecutionContext) = {
+    transactionsTable.insertOrUpdate(transaction).map(_ => Done)
+  }
+
+  def createTable(): Future[Unit] = dbConfig.db.run(transactionsTable.schema.createIfNotExists)
+
+  private class TransactionsTable(tag: Tag) extends Table[Transaction](tag, "TRANSACTIONS") {
+    override def * = (transactionId, eventName, amount).mapTo[Transaction]
+
+    def transactionId = column[String]("TRANSACTION_ID", O.PrimaryKey)
+
+    def eventName = column[String]("EVENT_NAME")
+
+    def amount = column[Int]("AMOUNT")
+  }
+}
+

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -1,83 +1,88 @@
 package myapp.application.projection.transaction
 
-import akka.Done
+import akka.actor.typed.ActorSystem
 import akka.persistence.query.Offset
-import akka.projection.ProjectionId
+import akka.projection.Projection
 import akka.projection.eventsourced.EventEnvelope
-import akka.projection.scaladsl.Handler
-import akka.projection.testkit.scaladsl.{ ProjectionTestKit, TestProjection, TestSourceProvider }
+import akka.projection.scaladsl.SourceProvider
+import akka.projection.testkit.scaladsl.{ ProjectionTestKit, TestSourceProvider }
 import akka.stream.scaladsl.Source
+import com.typesafe.config.Config
+import lerna.testkit.airframe.DISessionSupport
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.util.trace.TraceId
 import myapp.adapter.account.TransactionId
 import myapp.application.account.BankAccountBehavior.{ Deposited, DomainEvent, Refunded, Withdrew }
-import myapp.application.projection.AppEventHandler
+import myapp.application.projection.AppEventHandler.BehaviorSetup
+import myapp.readmodel.{ JDBCSupport, ReadModeDIDesign }
 import myapp.utility.AppRequestContext
+import myapp.utility.scalatest.StandardSpec
 import myapp.utility.tenant.TenantA
-import org.scalatest.wordspec.AnyWordSpecLike
-import slick.dbio.DBIO
+import wvlet.airframe.{ newDesign, Design }
 
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
+@SuppressWarnings(
+  Array(
+    "org.wartremover.contrib.warts.MissingOverride",
+    "org.wartremover.warts.Equals",
+    "org.wartremover.warts.IsInstanceOf",
+  ),
+)
+class BankTransactionEventHandlerSpec
+    extends ScalaTestWithTypedActorTestKit()
+    with StandardSpec
+    with DISessionSupport
+    with JDBCSupport {
 
-object BankTransactionEventHandlerSpec {
-  class MockTransactionRepository extends TransactionRepository {
-    @SuppressWarnings(Array("org.wartremover.warts.Var"))
-    var table: Vector[Transaction] = Vector[Transaction]()
-
-    override def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done] = DBIO.successful {
-      table :+= transaction
-      Done
-    }
-  }
-}
-
-class BankTransactionEventHandlerSpec extends ScalaTestWithTypedActorTestKit() with AnyWordSpecLike {
-  import BankTransactionEventHandlerSpec._
-
-  private val projectionTestKit = ProjectionTestKit(system)
-
-  def createEnvelope(event: DomainEvent, seqNo: Long, timestamp: Long = 0L): EventEnvelope[DomainEvent] =
-    EventEnvelope(Offset.sequence(seqNo), "persistenceId", seqNo, event, timestamp)
-
-  def converter(
-      handler: AppEventHandler[DomainEvent],
-  )(implicit ec: ExecutionContext): Handler[EventEnvelope[DomainEvent]] = { envelope: EventEnvelope[DomainEvent] =>
-    Future {
-      handler.process(envelope)
-      Done
-    }
-  }
+  override protected val diDesign: Design = newDesign
+    .add(ReadModeDIDesign.readModelDDesign)
+    .bind[Config].toInstance(testKit.config)
+    .bind[ActorSystem[Nothing]].toInstance(system)
+    .bind[TransactionRepository].to[TransactionRepositoryImpl]
 
   "BankTransactionEventHandler" should {
-    "process transaction events" in {
-      implicit val ec: ExecutionContextExecutor         = system.executionContext
-      implicit val appRequestContext: AppRequestContext = AppRequestContext(TraceId("trace_id"), TenantA)
-      val repository                                    = new MockTransactionRepository()
-      val handler                                       = new BankTransactionEventHandler(system, repository)
+    import tableSeeds._
+    import tables._
+    import tables.profile.api._
 
-      val events = Source(
-        List(
-          createEnvelope(Deposited(TransactionId("id0"), BigInt(100000)), 0L),
-          createEnvelope(Withdrew(TransactionId("id1"), BigInt(5000)), 1L),
-          createEnvelope(Withdrew(TransactionId("id2"), BigInt(10000)), 2L),
-          createEnvelope(Refunded(TransactionId("id3"), TransactionId("id2"), BigInt(2000)), 3L),
-          createEnvelope(Deposited(TransactionId("id4"), BigInt(200000)), 4L),
-        ),
+    val projectionTestKit = ProjectionTestKit(system)
+    val setup             = BehaviorSetup(system, jdbcService.dbConfig, tenant)
+
+    def createEnvelope(event: DomainEvent, seqNo: Long, timestamp: Long = 0L): EventEnvelope[DomainEvent] =
+      EventEnvelope(Offset.sequence(seqNo), "persistenceId", seqNo, event, timestamp)
+
+    def createProjection(requests: EventEnvelope[DomainEvent]*): Projection[EventEnvelope[DomainEvent]] = {
+      val source = Source(requests)
+      val sourceProvider: SourceProvider[Offset, EventEnvelope[DomainEvent]] =
+        TestSourceProvider[Offset, EventEnvelope[DomainEvent]](source, extractOffset = env => env.offset)
+      diSession.build[BankTransactionEventHandler].createProjection(setup, sourceProvider)
+    }
+
+    "process transaction events" in withJDBC { db =>
+      implicit val appRequestContext: AppRequestContext = AppRequestContext(TraceId("trace_id"), TenantA)
+
+      val events: Vector[DomainEvent] = Vector[DomainEvent](
+        Deposited(TransactionId("id0"), BigInt(100000)),
+        Withdrew(TransactionId("id1"), BigInt(5000)),
+        Withdrew(TransactionId("id2"), BigInt(10000)),
+        Refunded(TransactionId("id3"), TransactionId("id2"), BigInt(2000)),
+        Deposited(TransactionId("id4"), BigInt(200000)),
       )
 
-      val projectionId = ProjectionId("name", "key")
-      val sourceProvider =
-        TestSourceProvider[Offset, EventEnvelope[DomainEvent]](events, extractOffset = env => env.offset)
-      val projection = TestProjection(projectionId, sourceProvider, () => converter(handler))
+      val envelopedEvents: Vector[EventEnvelope[DomainEvent]] = events.zipWithIndex.map {
+        case (event, i) => createEnvelope(event, i)
+      }
 
+      val projection: Projection[EventEnvelope[DomainEvent]] = createProjection(envelopedEvents: _*)
+
+      val expected: Vector[TransactionStoreRow] = events.map {
+        case Deposited(id, amount)   => TransactionStoreRow(id.value, "Deposited", amount.longValue)
+        case Withdrew(id, amount)    => TransactionStoreRow(id.value, "Withdrew", amount.longValue)
+        case Refunded(id, _, amount) => TransactionStoreRow(id.value, "Refunded", amount.longValue)
+      }
       projectionTestKit.run(projection) {
-        repository.table shouldBe Vector(
-          Transaction("id0", "Deposited", 100000),
-          Transaction("id1", "Withdrew", 5000),
-          Transaction("id2", "Withdrew", 10000),
-          Transaction("id3", "Refunded", 2000),
-          Transaction("id4", "Deposited", 200000),
-        )
+        db.validate(TransactionStore.result) { result =>
+          result should contain theSameElementsAs expected
+        }
       }
     }
   }

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -1,0 +1,83 @@
+package myapp.application.projection.transaction
+
+import akka.Done
+import akka.persistence.query.Offset
+import akka.projection.ProjectionId
+import akka.projection.eventsourced.EventEnvelope
+import akka.projection.scaladsl.Handler
+import akka.projection.testkit.scaladsl.{ ProjectionTestKit, TestProjection, TestSourceProvider }
+import akka.stream.scaladsl.Source
+import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
+import lerna.util.trace.TraceId
+import myapp.adapter.account.TransactionId
+import myapp.application.account.BankAccountBehavior.{ Deposited, DomainEvent }
+import myapp.application.projection.AppEventHandler
+import myapp.utility.AppRequestContext
+import myapp.utility.tenant.TenantA
+import org.scalatest.wordspec.AnyWordSpecLike
+import slick.dbio.DBIO
+
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
+
+object BankTransactionEventHandlerSpec {
+  class MockTransactionRepository extends TransactionRepository {
+    var table: Vector[Transaction] = Vector[Transaction]()
+
+    override def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done] = DBIO.successful {
+      table :+= transaction
+      Done
+    }
+  }
+}
+
+class BankTransactionEventHandlerSpec extends ScalaTestWithTypedActorTestKit() with AnyWordSpecLike {
+  import BankTransactionEventHandlerSpec._
+
+  private val projectionTestKit = ProjectionTestKit(system)
+
+  def createEnvelope(event: DomainEvent, seqNo: Long, timestamp: Long = 0L): EventEnvelope[DomainEvent] =
+    EventEnvelope(Offset.sequence(seqNo), "persistenceId", seqNo, event, timestamp)
+
+  def converter(
+      handler: AppEventHandler[DomainEvent],
+  )(implicit ec: ExecutionContext): Handler[EventEnvelope[DomainEvent]] = { envelope: EventEnvelope[DomainEvent] =>
+    Future {
+      handler.process(envelope)
+      Done
+    }
+  }
+
+  "BankTransactionEventHandler" should {
+    "process transaction events" in {
+      implicit val ec: ExecutionContextExecutor         = system.executionContext
+      implicit val appRequestContext: AppRequestContext = AppRequestContext(TraceId("trace_id"), TenantA)
+      val repository                                    = new MockTransactionRepository()
+      val handler                                       = new BankTransactionEventHandler(repository)
+
+      val events = Source(
+        List(
+          createEnvelope(Deposited(TransactionId("id0"), BigInt(100000)), 0L),
+          createEnvelope(Deposited(TransactionId("id1"), BigInt(5000)), 0L),
+          createEnvelope(Deposited(TransactionId("id2"), BigInt(10000)), 0L),
+          createEnvelope(Deposited(TransactionId("id3"), BigInt(2000)), 0L),
+          createEnvelope(Deposited(TransactionId("id4"), BigInt(200000)), 0L),
+        ),
+      )
+
+      val projectionId = ProjectionId("name", "key")
+      val sourceProvider =
+        TestSourceProvider[Offset, EventEnvelope[DomainEvent]](events, extractOffset = env => env.offset)
+      val projection = TestProjection(projectionId, sourceProvider, () => converter(handler))
+
+      projectionTestKit.run(projection) {
+        repository.table shouldBe Vector(
+          Transaction("id0", "Deposited", 100000),
+          Transaction("id1", "Deposited", 5000),
+          Transaction("id2", "Deposited", 10000),
+          Transaction("id3", "Deposited", 2000),
+          Transaction("id4", "Deposited", 200000),
+        )
+      }
+    }
+  }
+}

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -76,10 +76,13 @@ class BankTransactionEventHandlerSpec
 
       val expected: Vector[TransactionStoreRow] = events.foldLeft(Vector[TransactionStoreRow]()) { (acc, event) =>
         event match {
-          case Deposited(id, amount)   => acc :+ TransactionStoreRow(id.value, "Deposited", amount.longValue)
-          case Withdrew(id, amount)    => acc :+ TransactionStoreRow(id.value, "Withdrew", amount.longValue)
-          case Refunded(id, _, amount) => acc :+ TransactionStoreRow(id.value, "Refunded", amount.longValue)
-          case _                       => acc
+          case Deposited(id, amount) =>
+            acc :+ TransactionStoreRow(id.value, TransactionEventType.Deposited.toString, amount.longValue)
+          case Withdrew(id, amount) =>
+            acc :+ TransactionStoreRow(id.value, TransactionEventType.Withdrew.toString, amount.longValue)
+          case Refunded(id, _, amount) =>
+            acc :+ TransactionStoreRow(id.value, TransactionEventType.Refunded.toString, amount.longValue)
+          case _ => acc
         }
       }
       projectionTestKit.run(projection) {

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -24,7 +24,6 @@ import wvlet.airframe.{ newDesign, Design }
   Array(
     "org.wartremover.contrib.warts.MissingOverride",
     "org.wartremover.warts.Equals",
-    "org.wartremover.warts.IsInstanceOf",
   ),
 )
 class BankTransactionEventHandlerSpec

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -53,7 +53,7 @@ class BankTransactionEventHandlerSpec extends ScalaTestWithTypedActorTestKit() w
       implicit val ec: ExecutionContextExecutor         = system.executionContext
       implicit val appRequestContext: AppRequestContext = AppRequestContext(TraceId("trace_id"), TenantA)
       val repository                                    = new MockTransactionRepository()
-      val handler                                       = new BankTransactionEventHandler(repository)
+      val handler                                       = new BankTransactionEventHandler(system, repository)
 
       val events = Source(
         List(

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -74,10 +74,13 @@ class BankTransactionEventHandlerSpec
 
       val projection: Projection[EventEnvelope[DomainEvent]] = createProjection(envelopedEvents: _*)
 
-      val expected: Vector[TransactionStoreRow] = events.map {
-        case Deposited(id, amount)   => TransactionStoreRow(id.value, "Deposited", amount.longValue)
-        case Withdrew(id, amount)    => TransactionStoreRow(id.value, "Withdrew", amount.longValue)
-        case Refunded(id, _, amount) => TransactionStoreRow(id.value, "Refunded", amount.longValue)
+      val expected: Vector[TransactionStoreRow] = events.foldLeft(Vector[TransactionStoreRow]()) { (acc, event) =>
+        event match {
+          case Deposited(id, amount)   => acc :+ TransactionStoreRow(id.value, "Deposited", amount.longValue)
+          case Withdrew(id, amount)    => acc :+ TransactionStoreRow(id.value, "Withdrew", amount.longValue)
+          case Refunded(id, _, amount) => acc :+ TransactionStoreRow(id.value, "Refunded", amount.longValue)
+          case _                       => acc
+        }
       }
       projectionTestKit.run(projection) {
         db.validate(TransactionStore.result) { result =>

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
 
 object BankTransactionEventHandlerSpec {
   class MockTransactionRepository extends TransactionRepository {
+    @SuppressWarnings(Array("org.wartremover.warts.Var"))
     var table: Vector[Transaction] = Vector[Transaction]()
 
     override def save(transaction: Transaction)(implicit ec: ExecutionContext): DBIO[Done] = DBIO.successful {

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -83,7 +83,7 @@ class BankTransactionEventHandlerSpec
 
       projectionTestKit.run(projection) {
         db.validate(TransactionStore.result) { result =>
-          result should contain theSameElementsAs expected
+          expect(result === expected)
         }
       }
     }

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -74,17 +74,14 @@ class BankTransactionEventHandlerSpec
 
       val projection: Projection[EventEnvelope[DomainEvent]] = createProjection(envelopedEvents: _*)
 
-      val expected: Vector[TransactionStoreRow] = events.foldLeft(Vector[TransactionStoreRow]()) { (acc, event) =>
-        event match {
-          case Deposited(id, amount) =>
-            acc :+ TransactionStoreRow(id.value, TransactionEventType.Deposited.toString, amount.longValue)
-          case Withdrew(id, amount) =>
-            acc :+ TransactionStoreRow(id.value, TransactionEventType.Withdrew.toString, amount.longValue)
-          case Refunded(id, _, amount) =>
-            acc :+ TransactionStoreRow(id.value, TransactionEventType.Refunded.toString, amount.longValue)
-          case _ => acc
-        }
-      }
+      val expected = Vector(
+        TransactionStoreRow("id0", "Deposited", 100000),
+        TransactionStoreRow("id1", "Withdrew", 5000),
+        TransactionStoreRow("id2", "Withdrew", 10000),
+        TransactionStoreRow("id3", "Refunded", 2000),
+        TransactionStoreRow("id4", "Deposited", 200000),
+      )
+
       projectionTestKit.run(projection) {
         db.validate(TransactionStore.result) { result =>
           result should contain theSameElementsAs expected

--- a/docker/mariadb/initdb/02_create_transaction_store.sql
+++ b/docker/mariadb/initdb/02_create_transaction_store.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS transaction_store(
+    transaction_id VARCHAR(255) NOT NULL,
+    transaction_type CHAR(16) NOT NULL,
+    amount BIGINT NOT NULL,
+    PRIMARY KEY (transaction_id)
+);


### PR DESCRIPTION
入出金明細を出力できるようにするために取引内容をQuery側DBに記録するようにする

## 参考

- https://doc.akka.io/docs/akka-projection/current/getting-started/index.html
- https://doc.akka.io/docs/akka-projection/current/slick.html#offset-in-a-relational-db-with-slick

## 変更

- Query側DBにアクセスするためのRepositoryを追加
- Projectionのユニットテストを追加
- `Deposited`,`Withdrew`,`Refunded`イベントの内容をクエリ側DBに保存できるよう実装
  - 現状の保存内容は以下のようになる
```
+----------------+------------------+--------+
| transaction_id | transaction_type | amount |
+----------------+------------------+--------+
| 1636591045     | Deposited        |    600 |
| 1636591056     | Withdrew         |    500 |
| 1636591077     | Refunded         |    300 |
+----------------+------------------+--------+
```