### PR TITLE
Lerna を最新スナップショットバージョンに更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 - 取引に紐づくコメントの作成・更新、削除機能を実装 [PR#35](https://github.com/lerna-stack/lerna-sample-account-app/pull/35)
 - RDBのアクセスを確認するヘルスチェック機能を追加 [PR#31](https://github.com/lerna-stack/lerna-sample-account-app/pull/31/)
 
+### Dependency Updates
+* akka-entity-replication 2.0.0 から 2.0.0+111-c87ff6bc-SNAPSHOT に更新しました
+* akka 2.6.12 から 2.6.17 に更新しました
+
 ## [v2021.10.0] - 2021-10-22
 [v2021.10.0]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2021.7.0...v2021.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 ### Dependency Updates
 * akka-entity-replication 2.0.0 から 2.0.0+111-c87ff6bc-SNAPSHOT に更新しました
 * akka 2.6.12 から 2.6.17 に更新しました
+* lerna-app-library 3.0.0 から 3.0.0-6-ca3f2b2b-SNAPSHOT に更新しました
+
 
 ## [v2021.10.0] - 2021-10-22
 [v2021.10.0]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2021.7.0...v2021.10.0

--- a/app/application/src/main/resources/reference.conf
+++ b/app/application/src/main/resources/reference.conf
@@ -135,6 +135,8 @@ akka.persistence {
     auto-start-snapshot-stores = [
       "akka-entity-replication.raft.persistence.cassandra-tenant-a.snapshot",
       "akka-entity-replication.raft.persistence.cassandra-tenant-b.snapshot",
+      "akka-entity-replication.eventsourced.persistence.cassandra-tenant-a.snapshot",
+      "akka-entity-replication.eventsourced.persistence.cassandra-tenant-b.snapshot",
       "myapp.application.remittance-orchestrator.persistence-tenant-a.snapshot",
       "myapp.application.remittance-orchestrator.persistence-tenant-b.snapshot",
       "myapp.application.remittance-orchestrator.sharding-state-persistence-tenant-a.snapshot",
@@ -248,13 +250,37 @@ akka-entity-replication.eventsourced.persistence.cassandra = ${akka.persistence.
     // See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/ for overriding any settings
     read-profile = "akka-entity-replication-profile"
   }
+
+  snapshot {
+    // Profile to use.
+    // See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/ for overriding any settings
+    read-profile = "akka-entity-replication-snapshot-profile"
+    write-profile = "akka-entity-replication-snapshot-profile"
+
+    // replication strategy to use.
+    replication-strategy = "NetworkTopologyStrategy"
+
+    // Replication factor list for data centers, e.g. ["dc0:3", "dc1:3"]. This setting is only used when replication-strategy is NetworkTopologyStrategy.
+    // Replication factors should be 3 or more to maintain data consisstency.
+    data-center-replication-factors = ["datacenter1:1"]
+
+    // Name of the keyspace to be used by the snapshot store
+    keyspace = "raft_commited_event_snapshot"
+
+    // Number load attempts when recovering from the latest snapshot fails yet older snapshot files are available.
+    // But old snapshots should be ignored because akka-entity-replication uses only the latest snapshot.
+    max-load-attempts = 1
+  }
+
 }
 
 akka-entity-replication.eventsourced.persistence.cassandra-tenant-a  = ${akka-entity-replication.eventsourced.persistence.cassandra} {
   journal.keyspace = "raft_commited_event_tenant_a"
+  snapshot.keyspace = "raft_commited_event_snapshot_tenant_a"
 }
 akka-entity-replication.eventsourced.persistence.cassandra-tenant-b = ${akka-entity-replication.eventsourced.persistence.cassandra} {
   journal.keyspace = "raft_commited_event_tenant_b"
+  snapshot.keyspace = "raft_commited_event_snapshot_tenant_b"
 }
 
 // You can find reference configuration at

--- a/app/application/src/main/scala/myapp/application/account/BankAccountApplicationImpl.scala
+++ b/app/application/src/main/scala/myapp/application/account/BankAccountApplicationImpl.scala
@@ -26,6 +26,9 @@ class BankAccountApplicationImpl(implicit system: ActorSystem[Nothing]) extends 
       .withEventSourcedJournalPluginId(
         s"akka-entity-replication.eventsourced.persistence.cassandra-${tenant.id}.journal",
       )
+      .withEventSourcedSnapshotStorePluginId(
+        s"akka-entity-replication.eventsourced.persistence.cassandra-${tenant.id}.snapshot",
+      )
 
     val entity = ReplicatedEntity(BankAccountBehavior.typeKey)(context => BankAccountBehavior(context))
       .withSettings(settings)

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,8 @@ ThisBuild / fork in Test := true
 // forkプロセスのstdoutをこのプロセスのstdout,stderrをこのプロセスのstderrに転送する
 // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき紛らわしいため
 ThisBuild / outputStrategy := Some(StdoutOutput)
+// TODO Remove this snapshot repo after stable version release
+ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
 
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.0.0"
+    val akkaEntityReplication    = "2.0.0+111-c87ff6bc-SNAPSHOT"
     val lerna                    = "3.0.0"
-    val akka                     = "2.6.12"
+    val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"
     val akkaProjection           = "1.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val akkaEntityReplication    = "2.0.0+111-c87ff6bc-SNAPSHOT"
-    val lerna                    = "3.0.0"
+    val lerna                    = "3.0.0-6-ca3f2b2b-SNAPSHOT"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"


### PR DESCRIPTION
サンプルリリースに向けて、
次の2つを最新のスナップショットバージョンに更新します。
* `akka-entity-replication`
* `lerna-app-library`

## マイグレーション (`akka-entity-replication`)
[Migration Guide](https://github.com/lerna-stack/akka-entity-replication/blob/a9d05142668a2fa8098b0bde25ff872276836a92/docs/migration_guide.md#210-from-200) に記載の方法で、スナップショットストアを構成する必要があります。

また、`akka-entity-replication` は、同じ Akka のバージョン (Akka 2.6.17)を使用することを推奨しています。
リリースノートは次の URL から確認できます。

* [Akka 2\.6\.13 Released \| Akka](https://akka.io/blog/news/2021/02/23/akka-2.6.13-released)
* [Akka 2\.6\.14 Released \| Akka](https://akka.io/blog/news/2021/04/08/akka-2.6.14-released)
* [Akka 2\.6\.15 Released \| Akka](https://akka.io/blog/news/2021/06/10/akka-2.6.15-released)
* [Akka 2\.6\.16 Released \| Akka](https://akka.io/blog/news/2021/08/19/akka-2.6.16-released)
* [Akka 2\.6\.17 Released \| Akka](https://akka.io/blog/news/2021/10/15/akka-2.6.17-released)

## 動作確認
* [x] このサンプルの README に記載の API が動作することを確認します (残高確認、入金、出金、返金、入出金明細出力、入出金明細へのコメントCRUD、送金)
* [x] 構成したスナップショットが使用されていることを確認します
* [x] ログ設定 (`app/utility/src/main/resources/logback.xml`) 更新がログ出力に反映されることを確認します。