### PR TITLE
ヘルスチェックの処理で自ノード以外のヘルスチェックアクターを利用してしまう問題を修正

### DIFF
--- a/app/application/src/main/resources/reference.conf
+++ b/app/application/src/main/resources/reference.conf
@@ -103,8 +103,6 @@ akka.actor {
     "myapp.application.account.RemittanceOrchestratorBehavior$Command" = jackson-cbor
     "myapp.application.account.RemittanceOrchestratorBehavior$Reply" = jackson-cbor
     "myapp.application.account.RemittanceOrchestratorBehavior$DomainEvent" = jackson-json
-    "myapp.application.util.healthcheck.JDBCHealthCheckService$Command" = jackson-json
-    "myapp.application.util.healthcheck.JDBCHealthCheckService$GetCurrentStatusReply" = jackson-json
   }
 }
 

--- a/app/application/src/main/scala/myapp/application/util/healthcheck/JDBCHealthCheck.scala
+++ b/app/application/src/main/scala/myapp/application/util/healthcheck/JDBCHealthCheck.scala
@@ -20,7 +20,7 @@ class JDBCHealthCheck(system: ActorSystem) extends (() => Future[Boolean]) {
     for {
       JDBCHealthCheckServiceKey.Listing(listing) <-
         system.toTyped.receptionist ? (Receptionist.find[JDBCHealthCheckService.Command](JDBCHealthCheckServiceKey, _))
-      jdbcHealthCheckService <- listing.headOption match {
+      jdbcHealthCheckService <- listing.find(_.ref.path.address.hasLocalScope) match {
         case Some(found) => Future.successful(found)
         case None        => Future.failed(new IllegalStateException("JDBCHealthCheckService is not ready"))
       }


### PR DESCRIPTION
`Receptionist`から取得したヘルスチェックアクターがリモートのアクターで想定外の動作をする問題を修正しました。

### 変更内容
- `Receptionist.find`で取得したアクターのリストを`hasLocalScope`でフィルタする処理を追加: https://github.com/lerna-stack/lerna-sample-account-app/commit/1c8aec26eebdd8a87a305046861b495c6be9ea61
- ヘルスチェックアクターとのやり取りで必要なクラスのSerializationの設定が不要なので削除: https://github.com/lerna-stack/lerna-sample-account-app/commit/86db9b143429cdf2acac51fef9076e3313cda575

### 動作確認
- ヘルスチェック機能が動作することを確認
  - ヘルスチェックエンドポイントにリクエスト(`curl --silent --noproxy "*" http://127.0.0.1:8558/ready`)なげて適切に`ok`,`not ok`返ってくること確認
  - 起動時にDBに異常があればシャットダウンすることを確認
- ヘルスチェックコマンドに関するserializationのWARNログなどが出力されないことを確認

### 参考文献
https://doc.akka.io/docs/akka/2.6.17/typed/actor-discovery.html#:~:text=You%20register,instance.
