### PR TITLE
akka-entity-replication を 2.0.0+280-0352e28d-SNAPSHOT に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 - RDBのアクセスを確認するヘルスチェック機能を追加 [PR#31](https://github.com/lerna-stack/lerna-sample-account-app/pull/31/)
 
 ### Dependency Updates
-* akka-entity-replication 2.0.0 から 2.0.0+111-c87ff6bc-SNAPSHOT に更新しました
+* akka-entity-replication 2.0.0 から 2.0.0+280-0352e28d-SNAPSHOT に更新しました
 * akka 2.6.12 から 2.6.17 に更新しました
 * lerna-app-library 3.0.0 から 3.0.0-6-ca3f2b2b-SNAPSHOT に更新しました
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.0.0+111-c87ff6bc-SNAPSHOT"
+    val akkaEntityReplication    = "2.0.0+280-0352e28d-SNAPSHOT"
     val lerna                    = "3.0.0-6-ca3f2b2b-SNAPSHOT"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
akka-entity-replication を最新スナップショット版 (2.0.0+280-0352e28d-SNAPSHOT) に更新します。

README に記載している 残高確認、入金、出金、返金、入出金明細出力、コメント作成・更新・削除、送金、バッチ入金を実行し、エラーが発生しないことを確認しました。