### PR TITLE
fix: Overwrites query.read-profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 
 ## Unreleased
 
+### Fixed
+- 送金オーケストレータ機能で Cassandra からイベントなどを読み込む際のプロファイルが書き込みの際に使われるプロファイルとは違うものになっていた問題を修正 [PR#42](https://github.com/lerna-stack/lerna-sample-account-app/pull/42)
+
 ### Added
 - 口座番号とテナントに紐づく入出金明細を出力する実装を追加 [PR#32](https://github.com/lerna-stack/lerna-sample-account-app/pull/32),
 [PR#34](https://github.com/lerna-stack/lerna-sample-account-app/pull/34)

--- a/app/application/src/main/resources/reference.conf
+++ b/app/application/src/main/resources/reference.conf
@@ -33,6 +33,9 @@ myapp.application {
       journal {
         keyspace = "remittance"
       }
+      query {
+        read-profile = "remittance-orchestrator-profile"
+      }
       # Snapshot は使用しないが、重要項目だけ設定してある
       snapshot {
         read-profile = "remittance-orchestrator-snapshot-profile"
@@ -58,6 +61,9 @@ myapp.application {
       write-profile = "remittance-orchestrator-sharding-state-profile"
       journal {
         keyspace = "remittance_sharding_state"
+      }
+      query {
+        read-profile = "remittance-orchestrator-sharding-state-profile"
       }
       snapshot {
         read-profile = "remittance-orchestrator-sharding-state-snapshot-profile"


### PR DESCRIPTION
We should use the same profile as for writing

## relation
- https://github.com/lerna-stack/lerna-sample-account-app/pull/21