### PR TITLE
BankAccountBehavior でデータ不整合の検出する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2022.3.0...main
 
+### Added
+- `BankAccountBehavior` にデータ不整合検出を実装しました [PR#47](https://github.com/lerna-stack/lerna-sample-account-app/pull/47)
+
 
 ## [v2022.3.0] - 2022-3-25
 [v2022.3.0]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2021.10.0...v2022.3.0

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -21,23 +21,23 @@ class BankTransactionEventHandler(repository: TransactionRepository)
     implicit val requestContext: AppRequestContext = envelope.event.appRequestContext
 
     envelope.event match {
-      case Deposited(accountNo, transactionId, amount, balance, transactedAt) =>
+      case Deposited(accountNo, _, transactionId, amount, balance, transactedAt) =>
         logger.info("Deposited(transactionId: {}, amount: {})", transactionId, amount)
         repository.save(
           Transaction(transactionId, TransactionEventType.Deposited, accountNo, amount, balance, transactedAt),
         )
-      case BalanceExceeded(transactionId) =>
+      case BalanceExceeded(_, transactionId) =>
         logger.info("BalanceExceeded(transactionId: {})", transactionId)
         DBIO.successful(Done)
-      case Withdrew(accountNo, transactionId, amount, balance, transactedAt) =>
+      case Withdrew(accountNo, _, transactionId, amount, balance, transactedAt) =>
         logger.info("Withdrew(transactionId: {}, amount: {})", transactionId, amount)
         repository.save(
           Transaction(transactionId, TransactionEventType.Withdrew, accountNo, amount, balance, transactedAt),
         )
-      case BalanceShorted(transactionId) =>
+      case BalanceShorted(_, transactionId) =>
         logger.info("BalanceShorted(transactionId: {})", transactionId)
         DBIO.successful(Done)
-      case Refunded(accountNo, transactionId, withdrawalTransactionId, amount, balance, transactedAt) =>
+      case Refunded(accountNo, _, transactionId, withdrawalTransactionId, amount, balance, transactedAt) =>
         logger.info(
           "Refunded(transactionId: {}, withdrawalTransactionId: {}, amount: {})",
           transactionId,
@@ -47,7 +47,7 @@ class BankTransactionEventHandler(repository: TransactionRepository)
         repository.save(
           Transaction(transactionId, TransactionEventType.Refunded, accountNo, amount, balance, transactedAt),
         )
-      case InvalidRefundRequested(transactionId, withdrawalTransactionId, amount) =>
+      case InvalidRefundRequested(transactionId, _, withdrawalTransactionId, amount) =>
         logger.info(
           "InvalidRefundRequested(transactionId: {}, withdrawalTransactionId: {}, amount: {}",
           transactionId,

--- a/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
+++ b/app/application/src/main/scala/myapp/application/projection/transaction/BankTransactionEventHandler.scala
@@ -26,7 +26,7 @@ class BankTransactionEventHandler(repository: TransactionRepository)
         repository.save(
           Transaction(transactionId, TransactionEventType.Deposited, accountNo, amount, balance, transactedAt),
         )
-      case BalanceExceeded(_, transactionId) =>
+      case BalanceExceeded(_, _, transactionId) =>
         logger.info("BalanceExceeded(transactionId: {})", transactionId)
         DBIO.successful(Done)
       case Withdrew(accountNo, _, transactionId, amount, balance, transactedAt) =>
@@ -34,7 +34,7 @@ class BankTransactionEventHandler(repository: TransactionRepository)
         repository.save(
           Transaction(transactionId, TransactionEventType.Withdrew, accountNo, amount, balance, transactedAt),
         )
-      case BalanceShorted(_, transactionId) =>
+      case BalanceShorted(_, _, transactionId) =>
         logger.info("BalanceShorted(transactionId: {})", transactionId)
         DBIO.successful(Done)
       case Refunded(accountNo, _, transactionId, withdrawalTransactionId, amount, balance, transactedAt) =>
@@ -47,7 +47,7 @@ class BankTransactionEventHandler(repository: TransactionRepository)
         repository.save(
           Transaction(transactionId, TransactionEventType.Refunded, accountNo, amount, balance, transactedAt),
         )
-      case InvalidRefundRequested(transactionId, _, withdrawalTransactionId, amount) =>
+      case InvalidRefundRequested(_, _, transactionId, withdrawalTransactionId, amount) =>
         logger.info(
           "InvalidRefundRequested(transactionId: {}, withdrawalTransactionId: {}, amount: {}",
           transactionId,

--- a/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
+++ b/app/application/src/test/scala/myapp/application/projection/transaction/BankTransactionEventHandlerSpec.scala
@@ -12,6 +12,7 @@ import lerna.testkit.airframe.DISessionSupport
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.util.trace.TraceId
 import myapp.adapter.account.{ AccountNo, TransactionId }
+import myapp.application.account.BankAccountBehavior.DomainEvent.EventNo
 import myapp.application.account.BankAccountBehavior.{ Deposited, DomainEvent, Refunded, Withdrew }
 import myapp.application.projection.AppEventHandler.BehaviorSetup
 import myapp.readmodel.{ JDBCSupport, ReadModeDIDesign }
@@ -61,11 +62,11 @@ class BankTransactionEventHandlerSpec
 
       val accountNo = AccountNo("1")
       val events: Vector[DomainEvent] = Vector[DomainEvent](
-        Deposited(accountNo, TransactionId("id0"), BigInt(100000), 100000, 0L),
-        Withdrew(accountNo, TransactionId("id1"), BigInt(5000), 95000, 0L),
-        Withdrew(accountNo, TransactionId("id2"), BigInt(10000), 85000, 0L),
-        Refunded(accountNo, TransactionId("id3"), TransactionId("id2"), BigInt(2000), 87000, 0L),
-        Deposited(accountNo, TransactionId("id4"), BigInt(200000), 287000, 0L),
+        Deposited(accountNo, EventNo(1), TransactionId("id0"), BigInt(100000), 100000, 0L),
+        Withdrew(accountNo, EventNo(2), TransactionId("id1"), BigInt(5000), 95000, 0L),
+        Withdrew(accountNo, EventNo(3), TransactionId("id2"), BigInt(10000), 85000, 0L),
+        Refunded(accountNo, EventNo(4), TransactionId("id3"), TransactionId("id2"), BigInt(2000), 87000, 0L),
+        Deposited(accountNo, EventNo(5), TransactionId("id4"), BigInt(200000), 287000, 0L),
       )
 
       val envelopedEvents: Vector[EventEnvelope[DomainEvent]] = events.zipWithIndex.map {


### PR DESCRIPTION
https://github.com/lerna-stack/akka-entity-replication/pull/180 に記載の方法を用いて、BankAccountBehavior でデータ不整合を検出します:
* イベント番号を検証することで、イベントの重複や欠落を検出できます
* イベント発行元口座を検証することで、イベントの誤配送を検出できます