### PR TITLE
Cassandraデータ閲覧機能を追加

### DIFF
--- a/app/data-viewer/README.md
+++ b/app/data-viewer/README.md
@@ -1,0 +1,63 @@
+# Cassandra データ閲覧ツール
+HTTP server を起動して、HTTPリクエストすると Cassandra に保存されたデータ(Event, Snapshot)を取得・デシリアライズして確認する
+
+## API
+### Event
+```
+/{configPath}/event/{persistenceId}/{fromSequenceNr}?to={toSequenceNr}
+```
+
+- `persistenceId: String`: 取得する persistence-id
+- `fromSequenceNr: Long`: 取得開始する sequence-number
+- `toSequenceNr: Option[Long]`: デフォルト=`{fromSequenceNr}`
+
+#### 例
+- `/akka-entity-replication.raft.persistence.cassandra-tenant-a/event/raft:BankAccount-tenant-a:xxxxx:replica-group-1/0?to=10`
+- `/akka-entity-replication.raft.persistence.cassandra-tenant-a/event/raft:BankAccount-tenant-a:xxxxx:replica-group-1/5`
+
+### Snapshot
+```
+/{configPath}/event/{persistenceId}/{sequenceNr}
+```
+
+- `configPath: String`: 
+  - 例: `akka-entity-replication.raft.persistence.cassandra-tenant-a`
+- `persistenceId: String`: 取得する persistence-id
+- `sequenceNr: Long`: 取得する sequence-number
+
+#### 例
+- `/akka-entity-replication.raft.persistence.cassandra-tenant-a/snapshot/SnapshotStore:BankAccount:xxxxx:replica-group-1/0`
+
+## Config
+### HTTP Server の IP:Port
+```hocon
+myapp.data-viewer.server {
+  interface = "127.0.0.1"
+  port = 8080
+}
+```
+
+### Cassandra 接続先
+```hocon
+datastax-java-driver.basic {
+  contact-points.0 = "127.0.0.1:9042"
+  load-balancing-policy.local-datacenter = "datacenter1"
+}
+datastax-java-driver.advanced.auth-provider {
+  username = "cassandra" // CHANGEME
+  password = "cassandra" // CHANGEME
+}
+```
+
+#### 必要な権限
+読み取り権限のみ
+
+## packaging
+1. package
+    ```shell
+    sbt data-viewer/universal:packageBin
+    ```
+1. `./app/data-viewer/target/universal/` に作成されたzipを適当な場所に解凍
+1. 実行設定
+    - 必要に応じて `./conf/application.ini` の設定を変更
+1. `./bin/` フォルダ内の実行ファイルを実行

--- a/app/data-viewer/src/main/resources/application.conf
+++ b/app/data-viewer/src/main/resources/application.conf
@@ -1,0 +1,16 @@
+
+akka.persistence.journal.auto-start-journals = []
+akka.persistence.snapshot-store.auto-start-snapshot-stores = []
+
+datastax-java-driver.basic {
+  contact-points.0 = "127.0.0.1:9042"
+  load-balancing-policy.local-datacenter = "datacenter1"
+}
+datastax-java-driver.advanced.auth-provider {
+  username = "cassandra" // CHANGEME
+  password = "cassandra" // CHANGEME
+}
+
+// ssh port forwarding で cassandra に接続する場合
+// datastax-java-driver.basic.contact-points.0 = "127.1.2.3:9042"
+// datastax-java-driver.advanced.address-translator.class = "myapp.dataviewer.util.SshPortForwardingSupport"

--- a/app/data-viewer/src/main/resources/reference.conf
+++ b/app/data-viewer/src/main/resources/reference.conf
@@ -1,0 +1,4 @@
+myapp.data-viewer.server {
+  interface = "127.0.0.1"
+  port = 8080
+}

--- a/app/data-viewer/src/main/scala/myapp/dataviewer/CassandraDataViewer.scala
+++ b/app/data-viewer/src/main/scala/myapp/dataviewer/CassandraDataViewer.scala
@@ -1,0 +1,142 @@
+package myapp.dataviewer
+
+import akka.actor.ClassicActorSystemProvider
+import akka.serialization.SerializationExtension
+import akka.stream.alpakka.cassandra.CassandraSessionSettings
+import akka.stream.alpakka.cassandra.scaladsl.{ CassandraSession, CassandraSessionRegistry }
+import akka.stream.scaladsl.Source
+import akka.{ Done, NotUsed }
+import com.datastax.oss.driver.api.core.cql.PreparedStatement
+import com.datastax.oss.protocol.internal.util.Bytes
+
+import scala.concurrent.Future
+import scala.util.{ Failure, Success }
+
+trait DataViewer {
+  import DataViewer._
+
+  def fetch(persistenceType: PersistenceType): Source[(SequenceNr, Data), NotUsed]
+  def close(): Future[Done]
+}
+
+object DataViewer {
+  type Data       = AnyRef
+  type SequenceNr = Long
+
+  sealed trait PersistenceType
+
+  object PersistenceType {
+    final case class Event(
+        persistenceId: String,
+        fromSequenceNr: SequenceNr,
+        toSequenceNr: SequenceNr,
+    ) extends PersistenceType
+
+    final case class Snapshot(
+        persistenceId: String,
+        sequenceNr: SequenceNr,
+    ) extends PersistenceType
+  }
+}
+
+class CassandraDataViewer(configPath: String)(implicit system: ClassicActorSystemProvider) extends DataViewer {
+  import DataViewer._
+
+  private val serialization = SerializationExtension(system)
+
+  private val session: CassandraSession =
+    CassandraSessionRegistry(system).sessionFor(CassandraSessionSettings(configPath))
+
+  private val classicSystem = system.classicSystem
+  import classicSystem.dispatcher
+
+  override def close(): Future[Done] = session.close(dispatcher)
+
+  private val journalConfig  = classicSystem.settings.config.getConfig(configPath).getConfig("journal")
+  private val queryConfig    = classicSystem.settings.config.getConfig(configPath).getConfig("query")
+  private val snapshotConfig = classicSystem.settings.config.getConfig(configPath).getConfig("snapshot")
+
+  private val targetPartitionSize = journalConfig.getLong("target-partition-size")
+
+  private val preparedSelectEventsByPersistenceId: Future[PreparedStatement] = {
+    val keyspace = journalConfig.getString("keyspace")
+    val table    = journalConfig.getString("table")
+    val query =
+      s"""
+      SELECT * FROM $keyspace.$table WHERE
+        persistence_id = ? AND
+        partition_nr = ? AND
+        sequence_nr >= ? AND
+        sequence_nr <= ?
+    """
+
+    session.prepare(query)
+  }
+
+  private val preparedSelectSnapshotByPersistenceId: Future[PreparedStatement] = {
+    val keyspace = snapshotConfig.getString("keyspace")
+    val table    = snapshotConfig.getString("table")
+    val query =
+      s"""
+        SELECT * FROM $keyspace.$table WHERE
+          persistence_id = ? AND
+          sequence_nr = ?
+      """
+
+    session.prepare(query)
+  }
+
+  def waitForSetup: Future[Done.type] =
+    Future
+      .sequence(
+        Seq(
+          preparedSelectEventsByPersistenceId,
+          preparedSelectSnapshotByPersistenceId,
+        ),
+      ).map(_ => Done)
+
+  private def dataColumnNameOf(persistenceType: PersistenceType) = persistenceType match {
+    case _: PersistenceType.Event    => "event"
+    case _: PersistenceType.Snapshot => "snapshot_data"
+  }
+
+  override def fetch(persistenceType: PersistenceType): Source[(SequenceNr, Data), NotUsed] = {
+    val future: Future[Source[(SequenceNr, Data), NotUsed]] = for {
+      boundStatement <- {
+        import java.lang.{ Long => JLong }
+        persistenceType match {
+          case event: PersistenceType.Event =>
+            val fromSequenceNr = event.fromSequenceNr
+            val partitionNr    = (fromSequenceNr - 1L) / targetPartitionSize
+            preparedSelectEventsByPersistenceId.map { preparedStatement =>
+              preparedStatement
+                .bind(event.persistenceId, partitionNr: JLong, fromSequenceNr: JLong, event.toSequenceNr: JLong)
+                .setExecutionProfileName(queryConfig.getString("read-profile"))
+            }
+          case snapshot: PersistenceType.Snapshot =>
+            preparedSelectSnapshotByPersistenceId.map { preparedStatement =>
+              preparedStatement
+                .bind(snapshot.persistenceId, snapshot.sequenceNr: JLong)
+                .setExecutionProfileName(snapshotConfig.getString("read-profile"))
+            }
+        }
+      }
+    } yield {
+      session
+        .select(boundStatement)
+        .map { row =>
+          val sequenceNr = row.getLong("sequence_nr")
+          val bytes      = Bytes.getArray(row.getByteBuffer(dataColumnNameOf(persistenceType)))
+          val serId      = row.getInt("ser_id")
+          val manifest   = row.getString("ser_manifest")
+
+          serialization.deserialize(bytes, serId, manifest) match {
+            case Success(event)     => (sequenceNr, event)
+            case Failure(exception) => throw exception
+          }
+        }
+    }
+
+    Source.futureSource(future).mapMaterializedValue(_ => NotUsed)
+  }
+}

--- a/app/data-viewer/src/main/scala/myapp/dataviewer/DataViewerServer.scala
+++ b/app/data-viewer/src/main/scala/myapp/dataviewer/DataViewerServer.scala
@@ -1,0 +1,60 @@
+package myapp.dataviewer
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.common.EntityStreamingSupport
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.server.Directives
+import akka.stream.scaladsl.{ Flow, Source }
+import akka.util.ByteString
+import spray.json.{ DefaultJsonProtocol, JsString, JsValue, JsonFormat }
+
+import java.util.concurrent.ConcurrentHashMap
+
+object DataViewerServer extends App with Directives with SprayJsonSupport with DefaultJsonProtocol {
+  import DataViewer._
+
+  private implicit val system: ActorSystem = ActorSystem()
+
+  private type ConfigPath = String
+
+  private val cassandraDataViewerMap = new ConcurrentHashMap[ConfigPath, CassandraDataViewer]
+
+  private def pathToCassandraDataViewer(configPath: ConfigPath) =
+    cassandraDataViewerMap.computeIfAbsent(configPath, path => new CassandraDataViewer(path))
+
+  private implicit val streamingSupport: EntityStreamingSupport = EntityStreamingSupport
+    .json()
+    .withFramingRenderer(Flow[ByteString].intersperse(ByteString("[\n\t"), ByteString(",\n\t"), ByteString("\n]")))
+
+  private implicit val format: JsonFormat[Data] = new JsonFormat[Data] {
+    override def write(obj: Data): JsValue = JsString(obj.toString) // Data = AnyRef の json 変換定義が無いため 一律で String に変換する
+    override def read(json: JsValue): Data = ???                    // Not used when responding
+  }
+
+  val bindingRoute = pathPrefix(Segment) { configPath =>
+    concat(
+      path("event" / Segment / LongNumber) { (persistenceId, fromSequenceNr) =>
+        parameter("to".as[Long].withDefault(fromSequenceNr)) { toSequenceNr =>
+          val persistenceType                             = DataViewer.PersistenceType.Event(persistenceId, fromSequenceNr, toSequenceNr)
+          val source: Source[(SequenceNr, Data), NotUsed] = pathToCassandraDataViewer(configPath).fetch(persistenceType)
+          complete(source)
+        }
+      },
+      path("snapshot" / Segment / LongNumber) { (persistenceId, sequenceNr) =>
+        val persistenceType                             = DataViewer.PersistenceType.Snapshot(persistenceId, sequenceNr)
+        val source: Source[(SequenceNr, Data), NotUsed] = pathToCassandraDataViewer(configPath).fetch(persistenceType)
+        complete(source)
+      },
+    )
+  }
+
+  private val config = system.settings.config
+  val interface      = config.getString("myapp.data-viewer.server.interface")
+  val port           = config.getInt("myapp.data-viewer.server.port")
+
+  Http()
+    .newServerAt(interface, port)
+    .bindFlow(bindingRoute)
+}

--- a/app/data-viewer/src/main/scala/myapp/dataviewer/util/SshPortForwardingSupport.scala
+++ b/app/data-viewer/src/main/scala/myapp/dataviewer/util/SshPortForwardingSupport.scala
@@ -1,0 +1,32 @@
+package myapp.dataviewer.util
+
+import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator
+import com.datastax.oss.driver.api.core.context.DriverContext
+
+import java.net.{ InetAddress, InetSocketAddress }
+
+/** Cassandra Cluster への接続を ssh port forwarding 経由でできるようにする AddressTranslator.
+  *
+  * Cassandra Cluster との接続は以下の流れで行われるため、 server(Cassandra Cluster) と client(app) で認識するIPが違う場合は、変換が必要
+  * <li>1. 初回接続（どれか1 node）で、Cluster が認識している 自身のIP list をクライアントに伝える</li>
+  * <li>2. クライアントは1 のIP list それぞれとTCP接続を確立する</li>
+  *
+  * 前提<br>
+  * ssh port forwarding では以下のようにIPアドレスの第一オクテットを `127`` にするルールとする
+  * <li>`10.1.2.3` -> `127.1.2.3`</li>
+  * <li>`192.168.1.2` -> `127.168.1.2`</li>
+  */
+final case class SshPortForwardingSupport(driverContext: DriverContext) extends AddressTranslator {
+  override def translate(address: InetSocketAddress): InetSocketAddress = {
+    val newHost = address.getHostName.replaceAll("^[^.]+", "127")
+    val newAddress = new InetSocketAddress(
+      InetAddress.getByName(newHost),
+      address.getPort,
+    )
+    newAddress
+  }
+
+  override def close(): Unit = {
+    // do nothing
+  }
+}

--- a/app/data-viewer/src/test/resources/application-test.conf
+++ b/app/data-viewer/src/test/resources/application-test.conf
@@ -1,0 +1,20 @@
+include "application.conf"
+
+akka.actor.provider = "local"
+
+akka.actor.serialization-bindings {
+  "myapp.dataviewer.JsonSerializable" = jackson-json
+}
+
+akka-entity-replication.raft.persistence.cassandra-tenant-a = ${akka-entity-replication.raft.persistence.cassandra} {
+  journal {
+    keyspace = "journal_for_dataviewer_test"
+    keyspace-autocreate = true
+    tables-autocreate = true
+  }
+  snapshot {
+    keyspace = "snapshot_for_dataviewer_test"
+    keyspace-autocreate = true
+    tables-autocreate = true
+  }
+}

--- a/app/data-viewer/src/test/scala/myapp/dataviewer/CassandraDataViewerSpec.scala
+++ b/app/data-viewer/src/test/scala/myapp/dataviewer/CassandraDataViewerSpec.scala
@@ -1,0 +1,82 @@
+package myapp.dataviewer
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.{ ActorRef, Behavior }
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior }
+import akka.stream.scaladsl.Sink
+import myapp.utility.scalatest.SpecAssertions
+import org.scalatest.Inside
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.duration.DurationInt
+
+object CassandraDataViewerSpec {
+  object TestActor {
+    sealed trait Command
+    final case class Save(count: Int, replyTo: ActorRef[Done]) extends Command
+
+    sealed trait Event
+    final case class Saved(count: Int) extends Event with JsonSerializable
+
+    final case class State(count: Int) extends JsonSerializable
+
+    def apply(persistenceId: PersistenceId, journalPluginId: String): Behavior[Command] =
+      EventSourcedBehavior[Command, Event, State](
+        persistenceId = persistenceId,
+        emptyState = State(0),
+        commandHandler = (state, cmd) =>
+          cmd match {
+            case save: Save => Effect.persist(Saved(save.count)).thenReply(save.replyTo)(_ => Done)
+          },
+        eventHandler = (state, evt) =>
+          evt match {
+            case Saved(count) => state.copy(state.count + count)
+          },
+      ).withJournalPluginId(journalPluginId)
+  }
+}
+
+class CassandraDataViewerSpec extends ScalaTestWithActorTestKit() with SpecAssertions with AnyWordSpecLike with Inside {
+  import CassandraDataViewerSpec._
+  import TestActor._
+
+  private val configPath = "akka-entity-replication.raft.persistence.cassandra-tenant-a"
+
+  "CassandraDataViewer.fetch" should {
+    val persistenceId = PersistenceId.ofUniqueId(s"dummy-persistence-id-${System.currentTimeMillis().toString}")
+    val actor         = spawn(TestActor(persistenceId, s"$configPath.journal"))
+
+    val count1 = 11
+    val count2 = 44
+    val count3 = 99
+
+    val probe = createTestProbe[Done]()
+    actor ! Save(count1, probe.ref)
+    actor ! Save(count2, probe.ref)
+    actor ! Save(count3, probe.ref)
+    probe.receiveMessages(3, 20.seconds)
+
+    val raftViewer = new CassandraDataViewer(configPath)
+
+    "return events" in {
+      val fromSequenceNr: Long = 0
+      val toSequenceNr: Long   = 10
+      val persistenceType      = DataViewer.PersistenceType.Event(persistenceId.id, fromSequenceNr, toSequenceNr)
+
+      val results = raftViewer
+        .fetch(persistenceType)
+        .runWith(Sink.seq)
+        .futureValue
+
+      expect {
+        results === List(
+          (1, Saved(count1)),
+          (2, Saved(count2)),
+          (3, Saved(count3)),
+        )
+      }
+    }
+  }
+}

--- a/app/data-viewer/src/test/scala/myapp/dataviewer/JsonSerializable.scala
+++ b/app/data-viewer/src/test/scala/myapp/dataviewer/JsonSerializable.scala
@@ -1,0 +1,3 @@
+package myapp.dataviewer
+
+trait JsonSerializable

--- a/app/data-viewer/src/universal/conf/application.ini
+++ b/app/data-viewer/src/universal/conf/application.ini
@@ -1,0 +1,16 @@
+# sbt data-viewer/universal:packageBin 用設定
+
+# Server 設定
+-Dmyapp.data-viewer.server.interface=127.0.0.1
+-Dmyapp.data-viewer.server.port=8080
+
+# Cassandra 接続設定
+-Ddatastax-java-driver.basic.contact-points.0=127.0.0.1:9042
+-Ddatastax-java-driver.basic.load-balancing-policy.local-datacenter=datacenter1
+
+-Ddatastax-java-driver.advanced.auth-provider.username=cassandra
+-Ddatastax-java-driver.advanced.auth-provider.password=cassandra
+
+# # ssh port forwarding で cassandra に接続する場合
+# -Ddatastax-java-driver.basic.contact-points.0=127.1.2.3:9042
+# -Ddatastax-java-driver.advanced.address-translator.class=myapp.dataviewer.util.SshPortForwardingSupport

--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,7 @@ lazy val `data-viewer` =
       libraryDependencies ++= Seq(
         AkkaHttp.http,
         AkkaHttp.sprayJson,
-        Akka.actorTestKit   % Test,
+        Akka.actorTestKit % Test,
       ),
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,24 @@ lazy val `entrypoint` =
       ),
     )
 
+lazy val `data-viewer` =
+  (project in file("app/data-viewer"))
+    .enablePlugins(JavaAppPackaging)
+    .dependsOn(
+      `application`,
+      `testkit` % "test",
+    )
+    .settings(wartremoverSettings, coverageSettings)
+    .settings(
+      name := "data-viewer",
+      mainClass in Compile := Some("myapp.dataviewer.DataViewerServer"),
+      libraryDependencies ++= Seq(
+        AkkaHttp.http,
+        AkkaHttp.sprayJson,
+        Akka.actorTestKit   % Test,
+      ),
+    )
+
 lazy val `testkit` = (project in file("app/testkit"))
   .settings(wartremoverSettings, coverageSettings)
   .settings(


### PR DESCRIPTION
Cassandraに保存されているイベントとスナップショットを閲覧する機能を追加

使用方法は[README](https://github.com/lerna-stack/lerna-sample-account-app/blob/9cd65bac178dea27898d5b2611d9c67efb3e0678/app/data-viewer/README.md)を参照してください。