### PR TITLE
Release v2022.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ myapp に関する注目すべき変更はこのファイルで文書化され�
 このファイルの書き方に関する推奨事項については、[Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を確認してください。
 
 ## [Unreleased]
-[Unreleased]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2022.3.0...main
+[Unreleased]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2022.12.0...main
+
+
+## [v2022.12.0] - 2022-12-26
+[v2022.12.0]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2022.3.0...v2022.12.0
 
 ### Added
 - `BankAccountBehavior` にデータ不整合検出を実装しました [PR#47](https://github.com/lerna-stack/lerna-sample-account-app/pull/47)
 - Raftアクターのメンテナンス時に必要な設定の追加と、メンテナンス中のRaftアクターにメッセージを送った際の挙動を実装しました [PR#48](https://github.com/lerna-stack/lerna-sample-account-app/pull/48)
+
+### Dependency Updates
+* akka-entity-replication 2.1.0 から 2.2.0 に更新しました
 
 ## [v2022.3.0] - 2022-3-25
 [v2022.3.0]: https://github.com/lerna-stack/lerna-sample-account-app/compare/v2021.10.0...v2022.3.0

--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,6 @@ lazy val `application` = (project in file("app/application"))
   .settings(wartremoverSettings, coverageSettings)
   .settings(
     name := "application",
-    resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= Seq(
       Lerna.akkaEntityReplication,
       Lerna.utilSequence,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val akkaEntityReplication    = "2.1.0+217-353d066a-SNAPSHOT"
+    val akkaEntityReplication    = "2.2.0"
     val lerna                    = "3.0.1"
     val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"


### PR DESCRIPTION
- akka-entity-replicationをv2.2.0に更新します
- CHANGELOG に v2022.12.0 を記載します
